### PR TITLE
Add AgentFund MCP to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
+- AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol


### PR DESCRIPTION
Adding AgentFund MCP to Finance category.

Crowdfunding for AI agents on Base chain.

https://github.com/RioBot-Grind/agentfund-mcp