### PR TITLE
Add BGPT MCP to Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Web fetching, scraping, and search.
 - RivalSearchMCP — https://github.com/damionrashford/RivalSearchMCP
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
+- **[BGPT MCP](https://github.com/connerlambden/bgpt-mcp)** - Search scientific papers and retrieve structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Remote MCP server with free tier.
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch (SearXNG) — https://github.com/mnhlt/WebSearch-MCP and https://github.com/ihor-sokoliuk/mcp-searxng
@@ -434,11 +435,12 @@ Payments, market data, and finance tools.
 
 Papers, datasets, and domain data.
 
-- ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - Ancestry — https://github.com/reeeeemo/ancestry-mcp
-- Probe.dev — https://mcp.probe.dev
-- OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
+- ArXiv — https://github.com/blazickjp/arxiv-mcp-server
+- **[BGPT MCP](https://github.com/connerlambden/bgpt-mcp)** - Search scientific papers and retrieve structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Remote MCP server with free tier.
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
+- Probe.dev — https://mcp.probe.dev
 
 ---
 


### PR DESCRIPTION
Adds BGPT MCP to the Research & Data category.

**BGPT MCP** — Search scientific papers with structured experimental data extracted from full-text studies. Returns 25+ fields per paper including methods, results, sample sizes, limitations, and quality scores.

- GitHub: https://github.com/connerlambden/bgpt-mcp
- Website: https://bgpt.pro/mcp