### PR TITLE
Add HendryAvila/Hoofy — Spec-Driven Development MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Developer-focused MCP servers and tools.
 - Bucket — https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/cli#model-context-protocol
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
+- HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
## What

Adding [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy) to the **Development Tools** category.

Hoofy is a spec-driven development companion MCP server written in Go that provides persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single binary, zero dependencies. MIT License.