### PR TITLE
Add Commune MCP — email infrastructure for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Commune MCP — https://github.com/commune-sh/commune-mcp
 
 ---
 


### PR DESCRIPTION
Adding Commune MCP to the Communication category.

It's an MCP server specifically designed for agents that need email — not just a thin wrapper around Gmail or SMTP. The difference shows up quickly when you're building something like a support agent or an outbound pipeline: you need programmatic inbox creation, isolated threads per conversation, and emails that don't go to spam because they're coming from an `noreply@yourapp.com` address.

Commune handles all of that. Custom domains, full thread tracking, structured extraction on inbound mail so the agent doesn't have to parse raw text, and SMS too if needed.

Quick setup: `uvx commune-mcp` — no npm, no global installs.