### PR TITLE
Add Wireshark-MCP server for network packet analysis (Multi-language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- Wireshark-MCP — https://github.com/bx33661/Wireshark-MCP — A local MCP server that brings the power of Wireshark/TShark to AI assistants for network packet analysis.
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -521,6 +521,7 @@ AI モデルおよび ML サービスとの統合。
 - OSV — https://github.com/StacklokLabs/osv-mcp
 - Vulert — https://vulert.com
 - Thales / CDSP サーバー — シークレットや鍵管理のための各種 MCP 統合
+- Wireshark-MCP — https://github.com/bx33661/Wireshark-MCP — AIアシスタントにWireshark/TSharkのネットワークパケット分析機能を提供するローカルMCPサーバー。
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -370,6 +370,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 ## 카테고리: 보안 (🔒)
 
 - Semgrep — https://github.com/semgrep/mcp
+- Wireshark-MCP — https://github.com/bx33661/Wireshark-MCP — AI 비서에게 Wireshark/TShark의 네트워크 패킷 분석 기능을 제공하는 로컬 MCP 서버.
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -507,6 +507,7 @@ Shell、操作系统与任务自动化相关。
 - OSV — https://github.com/StacklokLabs/osv-mcp
 - Vulert — https://vulert.com
 - Thales / CDSP 类服务器 — 针对密钥与机密管理的 MCP 集成
+- Wireshark-MCP — https://github.com/bx33661/Wireshark-MCP — 一个基于 TShark 的本地 MCP 服务器，为 AI 助手提供 Wireshark 网络数据包抓包和分析功能。
 
 ---
 

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -523,6 +523,7 @@ AI 與機器學習服務整合：
 - OSV — https://github.com/StacklokLabs/osv-mcp
 - Vulert — https://vulert.com
 - Thales / CDSP 類伺服器 — 用於金鑰與機密管理的 MCP 整合
+- Wireshark-MCP — https://github.com/bx33661/Wireshark-MCP — 一個基於 TShark 的本地 MCP 伺服器，為 AI 助手提供 Wireshark 網路封包擷取和分析功能。
 
 ---
 


### PR DESCRIPTION
## Summary

- Adding Wireshark-MCP server to the Security list across all language READMEs (English, zh_CN, zh_TW, ja, ko).
- Provides network packet analysis capabilities (capture, protocol stats, field extraction).
- Local MCP server with TShark integration.

## Details

Wireshark-MCP is a local MCP server that brings the power of Wireshark/TShark to AI assistants. It allows AI to capture network traffic, analyze PCAP files, extract specific protocol fields, and summarize network statistics for security audits and troubleshooting.

**Server URL**: [https://github.com/bx33661/Wireshark-MCP](https://github.com/bx33661/Wireshark-MCP)