### PR TITLE
Add Screaming Frog SEO Spider MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Web fetching, scraping, and search.
 - NYTimes — https://github.com/angheljf/nyt
 - Google News — https://github.com/ChanMeng666/server-google-news
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server
+- Screaming Frog SEO Spider — https://github.com/bzsasson/screaming-frog-mcp
 - Search1API — https://github.com/fatwang2/search1api-mcp
 - RivalSearchMCP — https://github.com/damionrashford/RivalSearchMCP
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily


### PR DESCRIPTION
## Summary
- Adds [Screaming Frog SEO Spider MCP server](https://github.com/bzsasson/screaming-frog-mcp) to the **Search & Web** category
- Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants
- Language: Python

## Details
Entry added in alphabetical order within the Search & Web section, following the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)