### PR TITLE
Add MolTrust to Identity category

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Charting and diagram tools.
 Identity and access management.
 
 - Keycloak — https://github.com/ChristophEnglisch/keycloak-model-context-protocol
+- MolTrust — https://github.com/MoltyCel/moltrust-mcp-server
 
 ---
 


### PR DESCRIPTION
## What

Adds [MolTrust](https://github.com/MoltyCel/moltrust-mcp-server) to the **Identity (🆔)** category.

## About MolTrust

Decentralized agent identity and reputation toolkit — 11 MCP tools for DID creation, trust scoring, credential verification, and ERC-8004 on-chain identity integration.

| | |
|---|---|
| **Install** | `pip install moltrust-mcp-server` |
| **PyPI** | [moltrust-mcp-server](https://pypi.org/project/moltrust-mcp-server/) |
| **Version** | v0.4.0 |
| **Tools** | 11 |
| **Tests** | 32 |
| **License** | MIT |