### PR TITLE
Add defi-mcp — DeFi & crypto MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Payments, market data, and finance tools.
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
+- defi-mcp (DeFi & crypto primitives — real-time token prices, wallet balances, gas prices, and DEX swap quotes across 7 chains) — https://github.com/OzorOwn/defi-mcp
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit


### PR DESCRIPTION
Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the list. Provides 12 tools for real-time token prices (via CoinGecko), wallet balances (ETH + ERC-20), gas prices, and DEX swap quotes (via 1inch and Jupiter) across 7 chains including Solana.