### PR TITLE
Add DeFi MCP Server to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Payments, market data, and finance tools.
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
 - defi-mcp (DeFi & crypto primitives — real-time token prices, wallet balances, gas prices, and DEX swap quotes across 7 chains) — https://github.com/OzorOwn/defi-mcp
+- DeFi MCP (token prices, wallet balances, gas tracking, DEX quotes for 20+ blockchains) — https://github.com/OzorOwn/defi-mcp
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit


### PR DESCRIPTION
Adds [DeFi MCP Server](https://github.com/OzorOwn/defi-mcp) to the Finance (💹) category.

**What it does:** MCP server providing real-time token prices, wallet balances, gas tracking, and DEX quotes across 20+ blockchains (Ethereum, Solana, Base, Arbitrum, Polygon, etc.). Works with Claude Desktop, Cursor, and any MCP-compatible client.

**12 MCP tools:** `get_token_price`, `get_wallet_balance`, `get_gas_prices`, `get_dex_quote`, `get_trending_tokens`, `get_token_info`, `get_market_overview`, `get_historical_prices`, `get_portfolio_value`, `search_tokens`, `get_top_tokens`, `get_token_holders`.

Also available as a hosted REST API at https://agent-gateway-kappa.vercel.app/v1/defi-mcp/