### PR TITLE
Add evc-team-relay-mcp - MCP server for Obsidian vault access

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- EVC Team Relay MCP — https://github.com/entire-vc/evc-team-relay-mcp (MCP server that gives AI agents read/write access to your Obsidian vault via EVC Team Relay. Supports real-time collaborative editing.)
 
 ---
 


### PR DESCRIPTION
Add evc-team-relay-mcp to the Note Taking section.

EVC Team Relay MCP is an MCP server that gives AI agents read/write access to your Obsidian vault through EVC Team Relay. It lets Claude and other AI tools read your notes, search across your vault, and write back - all through the standard MCP protocol.

- GitHub: https://github.com/entire-vc/evc-team-relay-mcp
- PyPI: https://pypi.org/project/evc-team-relay-mcp/
- Works with Claude Desktop, Cursor, and other MCP clients
- Self-hosted, local-first approach

Homepage: https://entire.vc/team-relay/ai/
