### PR TITLE
Add GEOScore MCP server to Search & Web category

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- GEOScore — https://github.com/henu-wang/geoscore-mcp - AI search optimization (GEO). Scans website AI search readiness, generates llms.txt, Schema.org fixes, and meta tag optimization.
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -292,6 +292,7 @@
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch/SearXNG — https://github.com/mnhlt/WebSearch-MCP 与 https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors 与 RAG Web Browser — https://github.com/apify/actors-mcp-server 与 https://github.com/apify/mcp-server-rag-web-browser
+- GEOScore — https://github.com/henu-wang/geoscore-mcp — AI 搜索优化（GEO）。扫描网站 AI 搜索就绪度，生成 llms.txt、Schema.org 修复、meta 标签优化。
 
 ---
 


### PR DESCRIPTION
## Summary

- Add [GEOScore](https://github.com/henu-wang/geoscore-mcp) to the **Search & Web (🔍)** category in both English and Chinese READMEs
- GEOScore is an AI search optimization (GEO) MCP server that scans website AI search readiness, generates llms.txt, Schema.org fixes, and meta tag optimization

## Changes

- `README.md`: Added GEOScore entry to Search & Web section
- `README_zh_CN.md`: Added GEOScore entry to 搜索与网络 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)