### PR TITLE
Add Outlook Assistant to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Outlook MCP — https://github.com/littlebearapps/outlook-mcp
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
-- Outlook MCP — https://github.com/littlebearapps/outlook-mcp
+- Outlook Assistant — https://github.com/littlebearapps/outlook-assistant
 
 ---
 


### PR DESCRIPTION
Adds [Outlook Assistant](https://github.com/littlebearapps/outlook-assistant) to the Communication section.

MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.

Works with both personal Outlook.com and work/school Microsoft 365 accounts. Published on npm as `@littlebearapps/outlook-assistant`. MIT licensed.