### PR TITLE
Add Frostbyte MCP to Aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Single MCP endpoints that expose many integrations.
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy
 - MCP Aggregator / Combine — https://github.com/nazar256/combine-mcp
 - Magg — https://github.com/sitbon/magg
+- Frostbyte MCP — https://github.com/OzorOwn/frostbyte-mcp — One API key for 40+ developer APIs (geolocation, crypto prices, screenshots, DNS, web scraping, code execution, PDF generation). Works with Claude Desktop, Cursor, Windsurf.
 
 ---
 


### PR DESCRIPTION
Adds [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) to the Aggregators category.

**What it does**: Single MCP server giving AI agents access to 40+ developer APIs through one gateway — geolocation, crypto prices, screenshots, DNS, web scraping, code execution, PDF generation, and more.

**Why it fits Aggregators**: One `npx frostbyte-mcp` command provides 13 tools covering APIs that would otherwise need 10+ separate MCP servers.

- GitHub: https://github.com/OzorOwn/frostbyte-mcp
- License: MIT
- Works with: Claude Desktop, Cursor, Windsurf