### PR TITLE
Add Kryfto - 42-tool MCP server for web browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- Kryfto — https://github.com/ExceptionRegret/Kryfto — Open-source web-browsing backend for AI agents with a 42-tool MCP server, REST API for n8n/Zapier/Make, federated multi-engine search, and anti-bot stealth.
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---


### PR DESCRIPTION
## Add Kryfto to Search & Web section

[Kryfto](https://github.com/ExceptionRegret/Kryfto) is an open-source web-browsing backend for AI agents & workflow engines.

### Key Features
- **42-tool MCP server** for Claude Code, Cursor, and Codex
- **Full REST API** for n8n, Zapier, and Make
- **Federated multi-engine search** across multiple providers
- **Anti-bot stealth** for reliable web access
- **Enterprise infrastructure**: Postgres, Redis, BullMQ, MinIO
- **Self-hostable** for $5/mo flat

### Details
- **Language**: TypeScript
- **License**: Open Source
- **Repository**: https://github.com/ExceptionRegret/Kryfto