### PR TITLE
Add agentic-ads to Marketing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Mapping and geolocation.
 Marketing and analytics tools.
 
 - Agent Mindshare — https://agentmindshare.com
+- Agentic Ads — https://github.com/nicofains1/agentic-ads
 - Open Strategy Partners Marketing Tools — https://github.com/open-strategy-partners/osp_mark
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server


### PR DESCRIPTION
Adds [agentic-ads](https://github.com/nicofains1/agentic-ads) to the Marketing category.

**agentic-ads** is an ad monetization SDK for MCP servers. MCP server developers add a few lines of code and earn 70% revenue share on contextual affiliate ads. Think AdSense, but for AI agents instead of websites.

- MIT licensed
- 270 tests passing
- Live at https://agentic-ads-production.up.railway.app
- Published on npm as `agentic-ads`
- Supports both remote (HTTP) and local (stdio) transports