### PR TITLE
Add OBSD LaunchPad MCP to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- OBSD LaunchPad (full token lifecycle MCP for AI agents on Base — 12 tools: deploy, buy, sell, claim fees, quotes, referral, earnings via npx obsd-launchpad-mcp) — https://github.com/thryxagi/obsd-launchpad
 
 ---
 


### PR DESCRIPTION
## What

Adds [OBSD LaunchPad MCP](https://github.com/thryxagi/obsd-launchpad) to the Finance section.

## Why

Full token lifecycle MCP server for AI agents on Base chain. 12 tools covering deploy, buy, sell, claim fees, quotes, referral program, and earnings analytics — all via `npx obsd-launchpad-mcp`.

**Key features:**
- Zero-cost token deployment (we pay gas)
- 37.5% of all swap fees as passive OBSD income
- Treasury-backed intrinsic value floor (mathematically rising)
- Built-in affiliate program: `register_referral()` earns 5% of referred creators' fees forever
- 10 verified contracts on Base mainnet, 275 passing tests

**Install:** `npx -y obsd-launchpad-mcp`