### PR TITLE
Add Omnis Venture Intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
+- Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server


### PR DESCRIPTION
Adds Omnis Venture Intelligence MCP to the Finance category.\n\n- GitHub: https://github.com/HCS412/ventureautomated\n- Glama: https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis\n- Remote MCP: https://www.bamboosnow.co/api/v1/mcp\n\nOmnis provides startup discovery, company scoring, monitoring, and enterprise workspace automation for autonomous agents.