### PR TITLE
Add preflight to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- preflight — https://github.com/TerminalGravity/preflight — 24-tool MCP server for Claude Code that catches vague prompts before they waste tokens. Includes 12-category scorecards, correction pattern learning, LanceDB semantic search across session history, and cross-service contract awareness.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
Adding [preflight](https://github.com/TerminalGravity/preflight) — a 24-tool MCP server for Claude Code that catches vague prompts before they waste tokens on wrong→fix cycles. Includes 12-category scorecards, correction pattern learning, LanceDB semantic search across session history, and cross-service contract awareness.