### PR TITLE
Add codewiki-mcp to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Developer-focused MCP servers and tools.
 - flutter-skill — https://github.com/ai-dashboad/flutter-skill — AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
 - marimo (⭐) — https://github.com/marimo-team/codemirror-mcp
 - Figma — https://github.com/GLips/Figma-Context-MCP
+- Codewiki — https://github.com/izzzzzi/codewiki-mcp — MCP server for codewiki.google — AI-powered wiki documentation for open-source repositories
 - Comet Opik (⭐) — https://github.com/comet-ml/opik-mcp
 - VSCode Devtools — https://github.com/biegehydra/BifrostMCP
 - Mastra/mcp (⭐) — https://github.com/mastra-ai/mastra/tree/main/packages/mcp


### PR DESCRIPTION
## Summary

- Adds [codewiki-mcp](https://github.com/izzzzzi/codewiki-mcp) to the **Development Tools** category
- MCP server for [codewiki.google](https://codewiki.google) — AI-powered wiki documentation for open-source repositories. Search repos, fetch wiki content, and ask questions about any repo.
- TypeScript | MIT License | [npm: codewiki-mcp](https://www.npmjs.com/package/codewiki-mcp)