### PR TITLE
Add iz-tolk-mcp to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Payments, market data, and finance tools.
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
+- iz-tolk-mcp — https://github.com/izzzzzi/izTolkMcp — MCP server for the Tolk smart contract compiler on the TON blockchain
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit


### PR DESCRIPTION
## Summary

- Adds [iz-tolk-mcp](https://github.com/izzzzzi/izTolkMcp) to the **Finance** category
- MCP server for the Tolk smart contract compiler on the TON blockchain. Compile, syntax check, deploy link generation, language docs, stdlib, and contract prompts.
- TypeScript | MIT License | [npm: iz-tolk-mcp](https://www.npmjs.com/package/iz-tolk-mcp)