### PR TITLE
Add Lightning Memory to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- Lightning Memory (agent memory for the Lightning/L402 economy) — https://github.com/singularityjason/lightning-memory
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Lightning Memory](https://github.com/singularityjason/lightning-memory) to the Finance (💹) category

Lightning Memory is an MCP server providing persistent agent memory for the Lightning economy. Features:

- Vendor reputation tracking for L402 API endpoints
- Spending anomaly detection for Lightning payments
- Nostr identity via BIP-340 Schnorr keypairs
- L402 payment gateway for agent-to-agent knowledge markets
- Local-first SQLite with FTS5 full-text search
- 9 MCP tools

Install: `pip install lightning-memory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)