### PR TITLE
Add Resolve MCP Server to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Access observability and monitoring systems.
 - sslmon — https://github.com/firesh/sslmon-mcp
 - Signoz — https://github.com/DrDroidLab/signoz-mcp-server
 - VictoriaMetrics — https://github.com/VictoriaMetrics-Community/mcp-victoriametrics
+- Resolve — https://github.com/unitedideas/resolve-mcp
 
 ---
 


### PR DESCRIPTION
Adds [Resolve MCP Server](https://github.com/unitedideas/resolve-mcp) to the Monitoring section.

Structured error recovery for AI agents. Returns resolution playbooks (backoff schedules, retry strategies, recovery steps) for 20+ services. Free tier: 500 requests/month.