### PR TITLE
chore: update Agent Governance Toolkit URLs to microsoft/ org

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Security-focused servers and scanning tools.
 - OSV — https://github.com/StacklokLabs/osv-mcp
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
-- Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- Agent OS — https://github.com/microsoft/agent-governance-toolkit — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
 
 ---
 


### PR DESCRIPTION
The Agent Governance Toolkit has moved to [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). This PR updates all references.