### PR TITLE
Add IndieStack MCP server to Search & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Web fetching, scraping, and search.
 - Exa Search (⭐) — https://github.com/exa-labs/exa-mcp-server
 - NYTimes — https://github.com/angheljf/nyt
 - Google News — https://github.com/ChanMeng666/server-google-news
+- IndieStack — https://github.com/Pattyboi101/indiestack - Open-source supply chain for AI agents — search and discover 3,000+ indie creations across 25 categories. 15 MCP tools including find_tools, build_stack, scan_project, compare_tools, and analyze_dependencies. Install via `uvx --from indiestack indiestack-mcp`.
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server
 - Search1API — https://github.com/fatwang2/search1api-mcp
 - RivalSearchMCP — https://github.com/damionrashford/RivalSearchMCP


### PR DESCRIPTION
## Summary

Adds [IndieStack](https://github.com/Pattyboi101/indiestack) to the Search & Web category.

IndieStack is an open-source supply chain for AI agents — a searchable marketplace of 3,000+ indie developer tools across 25 categories. It provides 15 MCP tools including `find_tools`, `build_stack`, `scan_project`, `compare_tools`, and `analyze_dependencies`.

- **PyPI**: Available via `uvx --from indiestack indiestack-mcp`
- **MCP Registry**: Listed on the official MCP Registry
- **Website**: [indiestack.ai](https://indiestack.ai)

The entry is placed in alphabetical order within the Search & Web section.