### PR TITLE
Add Frihet MCP server to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Payments, market data, and finance tools.
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
-- Frihet (AI-native business management — invoicing, expenses, clients, tax compliance, 31 tools) — https://github.com/berthelius/frihet-mcp
+- Frihet (AI-native business management — invoicing, expenses, clients, tax compliance, 31 tools) — https://github.com/Frihet-io/frihet-mcp
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit


### PR DESCRIPTION
## New MCP Server Submission

**Name:** Frihet (@frihet/mcp-server)
**Category:** Finance
**GitHub:** https://github.com/Frihet-io/frihet-mcp
**npm:** https://www.npmjs.com/package/@frihet/mcp-server
**Website:** https://www.frihet.io

### Description

AI-native business management MCP server with 31 tools for invoicing, expenses, clients, products, quotes, tax compliance (VeriFactu), and webhooks. Multi-currency (40 currencies), OCR, and Stripe Connect. MIT licensed.

### Features
- 31 tools covering full business management lifecycle
- Multi-currency support (40 currencies)
- Tax compliance (VeriFactu / Spain)
- OCR for expense receipt scanning
- Stripe Connect integration
- Remote MCP endpoint: https://mcp.frihet.io/mcp
- OAuth 2.0 + PKCE authentication