### PR TITLE
Add Dash MCP server to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- Dash — https://github.com/Kapeli/dash-mcp-server — MCP server for Dash, the macOS API documentation browser. Instant search over 200+ documentation sets.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
Adds [Kapeli/dash-mcp-server](https://github.com/Kapeli/dash-mcp-server) to the Development Tools section. Dash is the macOS API documentation browser with instant search over 200+ documentation sets.