### PR TITLE
Add AgentRank MCP server to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Developer-focused MCP servers and tools.
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
 - many others in Community Servers and Official Servers
+- AgentRank — https://github.com/superlowburn/agentrank — Live quality-scored index of 25,000+ MCP servers, updated daily. Search for maintained tools using real GitHub signals via 3 MCP tools.
 
 ---
 


### PR DESCRIPTION
Adds [AgentRank](https://github.com/superlowburn/agentrank) to the **Development Tools** category.

AgentRank is a live, quality-scored index of 25,000+ MCP servers, updated daily. It ranks tools by real GitHub maintenance signals (freshness, issue health, contributors, dependents, stars) and exposes 3 MCP tools so AI assistants can search and discover currently maintained tools at runtime.

- **GitHub:** https://github.com/superlowburn/agentrank
- **npm:** [agentrank-mcp-server](https://www.npmjs.com/package/agentrank-mcp-server)
- **Website:** https://agentrank-ai.com
- **Install:** `npx -y agentrank-mcp-server`