### PR TITLE
Add claw-mcp-toolkit to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- Claw MCP Toolkit (26 tools across 5 modules: crypto, web, social, finance, productivity. Zero config) — https://github.com/ElromEvedElElyon/claw-mcp-toolkit
 
 ---
 


### PR DESCRIPTION
Adding claw-mcp-toolkit - 26 tools across 5 modules (crypto, web, social, finance, productivity). Real-time crypto prices, web analysis, SEO checks, social content generation, portfolio tracking, and task management. Zero config, MIT license. Repo: https://github.com/ElromEvedElElyon/claw-mcp-toolkit