### PR TITLE
Add Reporecall — local codebase memory with hooks + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Web fetching, scraping, and search.
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server
 - Search1API — https://github.com/fatwang2/search1api-mcp
 - RivalSearchMCP — https://github.com/damionrashford/RivalSearchMCP
+- Reporecall — https://github.com/proofofwork-agency/reporecall - Local codebase memory with AST indexing (22 languages), call graphs, and hybrid search. Hooks + MCP server.
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode


### PR DESCRIPTION
## What it does

[Reporecall](https://github.com/proofofwork-agency/reporecall) gives Claude Code a codebase memory so it stops wasting tokens rediscovering your code.

**The problem:** Claude Code spends its first moves grepping and reading files to understand a codebase it's already seen. On large repos this burns through context window and token budget before real work starts.

**The solution:** Reporecall pre-indexes your codebase using Tree-sitter AST parsing (22 languages), builds call graphs, and injects relevant context via a hook in ~5ms — before Claude starts thinking. No grep chains, no exploration loops.

- Hybrid keyword + vector search
- Call graph traversal (callers + callees)
- Also works as an MCP server
- 3-8x reduction in token usage for context gathering

npm: `@proofofwork-agency/reporecall`