### PR TITLE
Add LystBot to Note Taking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Personal knowledge and notes integrations.
 - Apple Notes — https://github.com/sirmews/apple-notes-mcp (macOS)
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
+- LystBot — https://github.com/TourAround/LystBot (AI-powered list management. Create grocery lists, todos, packing lists. Check items, share with family. Free iOS + Android app.)
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 


### PR DESCRIPTION
Adds [LystBot](https://github.com/TourAround/LystBot) to the Note Taking category.

AI-powered list management MCP server. Create grocery lists, todos, packing lists. Check items off, share with family.

- npm: https://www.npmjs.com/package/lystbot
- Free iOS + Android app: https://lystbot.com