### PR TITLE
feat: add GodProfile MCP to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Developer-focused MCP servers and tools.
 
 ---
 
+- GodProfile — https://github.com/Luc0-0/GodProfile — MCP server generating animated glassmorphic SVGs for GitHub profiles. 16 tools: terminals, neural tech maps, live stat trophies, WakaTime, Spotify. Pure Python stdlib.
 ## Category: Data Visualization (📊)
 
 Charting and diagram tools.


### PR DESCRIPTION
## Summary

Adds [GodProfile](https://github.com/Luc0-0/GodProfile) to Development Tools.

GodProfile is an MCP server generating animated glassmorphic SVGs for GitHub profile READMEs. 16 tools: animated terminals, neural tech maps, live GitHub stat trophies, WakaTime charts, Spotify cards. Pure Python stdlib, zero deps.

## Preview

![banner](https://raw.githubusercontent.com/Luc0-0/GodProfile/main/assets/banner.svg)

![terminal](https://raw.githubusercontent.com/Luc0-0/GodProfile/main/assets/terminal.svg)

![neural map](https://raw.githubusercontent.com/Luc0-0/GodProfile/main/assets/neural_map.svg)