### PR TITLE
Add webclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- Webclaw — https://github.com/0xMassi/webclaw - Fast, local-first web content extraction for LLMs with TLS fingerprinting. 10 MCP tools for scraping, crawling, and structured data extraction.
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---


### PR DESCRIPTION
## What

Adds [webclaw](https://github.com/0xMassi/webclaw) to the **Search & Web** category.

## About webclaw

Fast, local-first web content extraction built for LLMs. Written in Rust with TLS fingerprinting (no browser needed for most sites). Ships an MCP server with 10 tools covering scraping, crawling, search, and structured data extraction.

- **GitHub**: https://github.com/0xMassi/webclaw
- **Language**: Rust
- **License**: MIT
- **Docker**: `ghcr.io/0xmassi/webclaw`

Fits alongside other web scraping and content extraction MCP servers in this category.