### PR TITLE
Add Rhumb — API discovery and scoring MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Single MCP endpoints that expose many integrations.
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy
 - MCP Aggregator / Combine — https://github.com/nazar256/combine-mcp
 - Magg — https://github.com/sitbon/magg
+- Rhumb — https://github.com/supertrained/rhumb — Discover, score, and execute external APIs for AI agents. 695+ services across 86 categories, AN Score (20-dimension framework), 16 MCP tools, zero-signup discovery, x402 micropayments. `npx rhumb-mcp`
 
 ---
 


### PR DESCRIPTION
## Add Rhumb to Aggregators

**What it does:**
[Rhumb](https://github.com/supertrained/rhumb) is an MCP server that helps AI agents discover, evaluate, and execute external APIs. It provides 16 tools covering discovery (`find_services`, `compare_services`, `search_by_capability`), scoring via AN Score (20-dimension trust framework across Execution quality and Access Readiness), and three credential modes for execution.

**Why it belongs in Aggregators:**
Rhumb aggregates intelligence about 695+ external APIs across 86 categories and surfaces them through standardized MCP tools, letting any AI agent find and evaluate the right external service for a task without hardcoding API knowledge.

**Key facts:**
- 695+ scored services across 86 categories
- AN Score: 20-dimension API trust framework
- 16 MCP tools for discovery, scoring, and execution
- Zero-signup access for discovery tools
- Three credential modes: bring-your-own, managed, x402 micropayments
- Listed on [Glama](https://glama.ai/mcp/servers/nnimnpwgem)

**Install:**
```json
{
  "mcpServers": {
    "rhumb": {
      "command": "npx",
      "args": ["-y", "rhumb-mcp"]
    }
  }
}
```