### PR TITLE
feat: add autonsol/atxp-mcp — agent-native tools (web search, image gen, email, music) via x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- sol-mcp (Solana token risk scoring + momentum signals for pump.fun launches) — https://github.com/autonsol/sol-mcp
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 - sol-mcp (Solana token risk scoring + momentum signals for pump.fun launches) — https://github.com/autonsol/sol-mcp
+- atxp-mcp (agent-native tools via ATXP infrastructure — web search free, image gen, email, music via x402 USDC micropayments on Base) — https://github.com/autonsol/atxp-mcp
 
 ---
 


### PR DESCRIPTION
## autonsol/atxp-mcp

Adding ATXP Agent Tools MCP to the Finance category.

**What it is:** MCP server wrapping the ATXP agent infrastructure. AI agents can use web search (free tier 3/day), image generation, email send/receive, and music generation via x402 micropayments on Base chain.

**Why Finance category:**
- All paid tools use x402 USDC micropayments on Base
- Agents get a persistent Ethereum wallet via ATXP
- Freemium model: web search free, all others $0.01-$0.15/call

**Links:**
- GitHub: https://github.com/autonsol/atxp-mcp
- Smithery: https://smithery.ai/servers/autonsol/atxp-mcp
- xpay.sh proxy: https://atxp-mcp.mcp.xpay.sh/mcp
- Railway (live): https://atxp-mcp-production.up.railway.app

Note: Same author as sol-mcp (already listed, PR #64).