### PR TITLE
Add Safari MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Web fetching, scraping, and search.
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
 - Playwright — https://github.com/executeautomation/mcp-playwright
+- Safari MCP — https://github.com/achiya-automation/safari-mcp — Native Safari browser automation for AI agents via AppleScript (80 tools, zero Chrome overhead, macOS only)
 - Websearch (SearXNG) — https://github.com/mnhlt/WebSearch-MCP and https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering


### PR DESCRIPTION
Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) — native Safari browser automation for AI agents. 80 tools via AppleScript, zero Chrome overhead, MIT licensed.

- **npm**: https://www.npmjs.com/package/safari-mcp
- **License**: MIT