### PR TITLE
Add polymarket-trading-mcp to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- polymarket-trading-mcp (trading intelligence tools for Polymarket: slippage, liquidity, arbitrage detection, price feeds, wallet intelligence) — https://github.com/whitmorelabs/polymarket-mcp
 
 ---
 


### PR DESCRIPTION
Adds [polymarket-trading-mcp](https://github.com/whitmorelabs/polymarket-mcp) to the Finance section.

Trading intelligence tools for Polymarket prediction markets: slippage estimation, liquidity depth, arbitrage detection, price feeds, and on-chain wallet intelligence. MIT licensed.