### PR TITLE
Add Sports Betting MCP server to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Payments, market data, and finance tools.
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
+- Sports Betting (live odds, injury reports, line movement, and AI pick generation across NBA, NHL, and NCAAB) — https://github.com/seang1121/sports-betting-mcp
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp


### PR DESCRIPTION
Adds [sports-betting-mcp](https://github.com/seang1121/sports-betting-mcp) to the Finance category.

MCP server for AI-powered sports betting analysis — live odds, injury reports, line movement, and pick generation across NBA, NHL, and NCAAB.

- Published on [PyPI](https://pypi.org/project/sports-betting-mcp/)
- 9 MCP tools
- Python 3.10+