### PR TITLE
Add defense-mcp-server to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- Defense MCP Server — https://github.com/bottobot/defense-mcp-server — 31 defensive security tools with 250+ actions for Linux system hardening, compliance auditing, firewall management, vulnerability scanning, and incident response. Dry-run by default.
 
 ---
 


### PR DESCRIPTION
## What
Adds [defense-mcp-server](https://github.com/bottobot/defense-mcp-server) to the Security section.

## Description
Defense MCP Server provides 31 defensive security tools with 250+ actions for Linux — system hardening, CIS/HIPAA/SOC2 compliance, firewall management (iptables/nftables/UFW), malware scanning, vulnerability detection, incident response, and more. All tools run dry-run by default with safety guardrails.

**npm:** `npm install -g defense-mcp-server`
**License:** MIT | **Language:** TypeScript | **Platform:** Linux