### PR TITLE
Add Toolradar MCP to Search & Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Web fetching, scraping, and search.
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
+- Toolradar MCP — https://github.com/Nadeus/toolradar-mcp - Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives
 
 ---
 


### PR DESCRIPTION
Adds [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) to the Search & Web section.

**What it does:** Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives.

- **npm:** `toolradar-mcp`
- **Install:** `npx -y toolradar-mcp`
- **Transport:** stdio
- **Free tier:** 100 API calls/day (no key required)
- **Tools:** `search_tools`, `get_tool`, `compare_tools`, `get_alternatives`, `get_pricing`, `list_categories`
- **License:** MIT

Works with Claude Desktop, Cursor, Windsurf, and Claude Code.