### PR TITLE
Add toad-eye to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Access observability and monitoring systems.
 - Sentry — https://github.com/modelcontextprotocol/servers/tree/main/src/sentry
 - sslmon — https://github.com/firesh/sslmon-mcp
 - Signoz — https://github.com/DrDroidLab/signoz-mcp-server
+- toad-eye — https://github.com/vola-trebla/toad-eye
 - VictoriaMetrics — https://github.com/VictoriaMetrics-Community/mcp-victoriametrics
 
 ---


### PR DESCRIPTION
**[toad-eye](https://github.com/vola-trebla/toad-eye)** — one-line observability for MCP servers.

- OTel-native traces + metrics for every tool call, resource read, and prompt
- 11 pre-built Grafana dashboards (MCP Server, MCP E2E, MCP Tool Analytics + 8 more)
- Client + server distributed tracing (CLIENT→SERVER spans linked in one trace)
- Tool hallucination detection (tracks -32601 JSON-RPC errors)
- Budget guards, privacy controls, semantic drift monitoring
- TypeScript, self-hosted, no vendor lock-in

**npm:** [toad-eye](https://www.npmjs.com/package/toad-eye)
**GitHub:** [vola-trebla/toad-eye](https://github.com/vola-trebla/toad-eye)

Added to Monitoring section in alphabetical order (between Signoz and VictoriaMetrics).