### PR TITLE
Add Safari MCP to Search & Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- Safari MCP — https://github.com/achiya-automation/safari-mcp - Native Safari browser automation with 80+ tools, dual-engine (Extension + AppleScript), zero Chrome overhead
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---


### PR DESCRIPTION
## What

Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) to the **Search & Web** section.

## About Safari MCP

- **Native Safari browser automation** for AI agents — no Chrome/Chromium required
- **80+ tools** covering navigation, interaction, forms, network capture, storage, accessibility, and more
- **Dual-engine architecture**: Safari Extension (preferred, ~5-20ms) + AppleScript daemon (fallback, ~5ms)
- Uses your real Safari with all existing logins and cookies
- **MIT licensed**
- Published on npm: `safari-mcp`

## Why it belongs here

Safari MCP is the only MCP server providing native Safari automation. All other browser MCP servers require Chrome/Chromium. It fills a gap for macOS users who want browser automation without the overhead of a separate browser process.