### PR TITLE
Add Novyx MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Personal knowledge and notes integrations.
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
+- Novyx MCP — https://github.com/novyxlabs/novyx-mcp (Persistent memory for AI agents with 107 tools: remember, recall, rollback, audit, knowledge graph, governed actions, eval, cortex, and Runtime v2 agent orchestration. Local SQLite or Novyx Cloud. MIT licensed.)
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 
 ---


### PR DESCRIPTION
Adds [Novyx MCP](https://github.com/novyxlabs/novyx-mcp) to the Note Taking category.

Novyx MCP is a persistent memory server for AI agents with 107 tools covering remember, recall, rollback, audit, knowledge graph, governed actions, eval, cortex, and Runtime v2 agent orchestration. Runs locally with SQLite (zero-config) or connects to Novyx Cloud.

- GitHub: https://github.com/novyxlabs/novyx-mcp
- PyPI: https://pypi.org/project/novyx-mcp/
- License: MIT