### PR TITLE
Add ORCA Agent Skills to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- ORCA Agent Skills — https://github.com/gfernandf/agent-skills
 
 ---
 


### PR DESCRIPTION
Adds [ORCA Agent Skills](https://github.com/gfernandf/agent-skills) to the AI Services section.

**What it does:** MCP server exposing 122+ executable AI agent skills and capabilities with DAG scheduling, auto-bindings for OpenAI and PythonCall, and adapters for LangChain, CrewAI, and Semantic Kernel.

- Available on PyPI: `pip install orca-agent-skills[mcp]`
- Includes a capability registry with YAML-defined contracts
- Built-in scaffold wizard for authoring new skills
- Apache 2.0 licensed