### PR TITLE
Add Antigravity Link to Development Tools category

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ AI model & ML service integrations.
 
 Developer-focused MCP servers and tools.
 
+- Antigravity Link — https://github.com/cafeTechne/antigravity-link-extension — MCP server + OpenAPI API to control Antigravity IDE instances (snapshot, send, stop generation, switch instance, task/walkthrough/plan retrieval) with a mobile companion UI.
 - CentralMind/Gateway — https://github.com/centralmind/gateway
 - Currents (⭐) — https://github.com/currents-dev/currents-mcp
 - Octocode — https://github.com/bgauryy/octocode-mcp


### PR DESCRIPTION
Adds Antigravity Link to the MCP server list.

- Repo: https://github.com/cafeTechne/antigravity-link-extension
- Includes MCP server + OpenAPI spec
- Supports snapshot/send/stop/switch instance + task/walkthrough/plan retrieval
- Includes mobile companion UI for Antigravity IDE sessions

Thanks for maintaining this directory.