### PR TITLE
Add operant-mcp to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- operant-mcp — https://github.com/operantlabs/operant-mcp — Open-source MCP server with 51 security testing tools for pentesting, vulnerability scanning, and security auditing. MIT licensed.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Security (🔒) category.

- Open-source MCP server with 51 security testing tools
- Covers pentesting, vulnerability scanning, and security auditing
- MIT licensed

## Details

operant-mcp is a comprehensive security testing MCP server with 51 tools including SQL injection testing (blind boolean, time-based, union extract), XSS detection, CORS checks, SSRF testing, authentication brute force, path traversal, IDOR testing, GraphQL introspection, recon tools (DNS, git secrets, S3, TLS), PCAP analysis, and more.

- GitHub: https://github.com/operantlabs/operant-mcp
- License: MIT