### PR TITLE
Add Database MCP to Community Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ A broad collection of community-maintained MCP servers (selected highlights — 
 - CalDAV MCP — https://github.com/dominik1001/caldav-mcp
 - Context-aware & discovery servers (context-awesome, ref, etc.)
 - Currents — https://github.com/currents-dev/currents-mcp
+- Database MCP — https://github.com/haymon-ai/database
 - DINO-X, Digma, Driflyte, DreamFactory, Dash0, DB-specific servers, and many more.
 
 (For the exhaustive long list of community servers and links, refer to the aggregated listings in community and official sections across the MCP ecosystem. This README collects and organizes the major categories and many example projects; the community maintains a rapidly growing set of servers — check the linked repos for the latest.)


### PR DESCRIPTION
Add Database MCP — a single-binary MCP server for MySQL, MariaDB, PostgreSQL & SQLite built in Rust with zero runtime dependencies.

- **URL**: https://github.com/haymon-ai/database
- **Website**: https://database.haymon.ai