### PR TITLE
Add safari-mcp — Native Safari browser automation for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Web fetching, scraping, and search.
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
 - Playwright — https://github.com/executeautomation/mcp-playwright
+- Safari MCP — https://github.com/achiya-automation/safari-mcp - Native Safari browser automation for AI agents on macOS. 80 tools, ~5ms per command, zero Chrome overhead.
 - Websearch (SearXNG) — https://github.com/mnhlt/WebSearch-MCP and https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering


### PR DESCRIPTION
## What

Adds [safari-mcp](https://github.com/achiya-automation/safari-mcp) to the **Search & Web** category.

## Why

Safari MCP is the only MCP server for native Safari automation on macOS:
- **80 tools**: navigate, click, fill forms, screenshot, network mocking, accessibility snapshots, device emulation
- **~5ms per command** via persistent Swift helper
- **Zero Chrome overhead** — reuses existing Safari with all logins intact
- **2,300+ weekly npm downloads**, listed on Official MCP Registry, Smithery, Glama, Cursor Directory
- MIT licensed

Placed after Playwright as a complementary browser automation option.