### PR TITLE
Add TokRepo MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Single MCP endpoints that expose many integrations.
 - SkillBoss — https://github.com/heeyo-life/skillboss-mcp — One API key for 100+ AI services (Claude, GPT, Gemini, DeepSeek, images, video, data scraping, payments, email, and more). OpenAI-compatible. Works in Claude Code, Cursor, Windsurf.
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev
+- TokRepo — https://github.com/henu-wang/tokrepo-mcp-server — Open registry MCP server for discovering and installing 220+ curated AI assets including skills, prompts, workflows, and MCP configs.
 - Pipedream — https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol
 - Zapier — https://zapier.com/mcp
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy


### PR DESCRIPTION
This adds TokRepo to the Aggregators category.

Why it fits:
- TokRepo ships a real MCP server (`npx tokrepo-mcp-server`)
- it acts as a single searchable entry point for reusable AI assets
- it helps users discover and install skills, prompts, workflows, and MCP configs from one registry

I kept the addition to a single line matching the current format.