### PR TITLE
Add Nucleus MCP to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- Nucleus MCP — https://github.com/eidetic-works/nucleus-mcp — 114 MCP tools for persistent memory, execution verification, governance, and compliance. GROUND verifies, ALIGN corrects, COMPOUND learns.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
## Add Nucleus MCP

Adds [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) to the **Development Tools** category.

**Entry:**
- Nucleus MCP — https://github.com/eidetic-works/nucleus-mcp — 114 MCP tools for persistent memory, execution verification, governance, and compliance. GROUND verifies, ALIGN corrects, COMPOUND learns.

**About Nucleus MCP:**
- 114 MCP tools across memory, governance, orchestration, and compliance
- Three-phase reliability loop: GROUND (execution verification), ALIGN (drift correction), COMPOUND (learning accumulation)
- Works with Claude Desktop, Claude Code, Cursor, Windsurf, and other MCP clients
- Install via PyPI (`pip install mcp-server-nucleus`) or npm (`npx mcp-server-nucleus`)
- Open source (MIT)