### PR TITLE
Add Asqav MCP to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- Asqav — https://github.com/jagmarques/asqav-mcp — AI agent governance MCP server with quantum-safe audit trails (ML-DSA-65), policy enforcement, threat detection, and compliance reporting. Works with Claude Desktop, Cursor, Claude Code. PyPI: `pip install asqav-mcp`.
 
 ---
 


### PR DESCRIPTION
Adds [asqav-mcp](https://github.com/jagmarques/asqav-mcp) to the Security category.

AI agent governance MCP server with quantum-safe audit trails (ML-DSA-65/FIPS 204), policy enforcement, threat detection, and compliance reporting. Works with Claude Desktop, Cursor, and Claude Code.

- PyPI: https://pypi.org/project/asqav-mcp/
- GitHub: https://github.com/jagmarques/asqav-mcp