### PR TITLE
Add FXMacroData — macroeconomic & FX data MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- FXMacroData (macroeconomic indicators, central bank policy rates, FX spot rates, COT positioning data, and economic release calendars for 18+ currencies) — https://github.com/fxmacrodata/fxmacrodata
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [FXMacroData](https://fxmacrodata.com) to the 💹 Finance category.

FXMacroData is a remote MCP server providing macroeconomic and FX market data:

- Macroeconomic indicators for 18+ currencies (inflation, GDP, PMI, policy rates, etc.)
- Central bank policy rates and rate decision history
- FX spot rates
- CFTC Commitment of Traders (COT) positioning data
- Economic release calendars

**Transport**: Streamable HTTP at `https://fxmacrodata.com/mcp`
**Auth**: OAuth 2.0 / API key (`?api_key=`)
**PyPI**: `pip install fxmacrodata`
**License**: MIT