### PR TITLE
Add Helium MCP to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- Helium MCP (real-time news with bias scoring across 5,000+ sources, AI-powered options pricing, balanced news synthesis, live market data, and meme search) — https://github.com/connerlambden/helium-mcp
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the **Finance (💹)** category

## About Helium MCP

Real-time news with bias scoring across 5,000+ sources (15+ dimensions), AI-powered options pricing, balanced news synthesis, live market data, and meme search.

- **URL:** https://heliumtrades.com/mcp (streamable HTTP, remote server)
- **GitHub:** https://github.com/connerlambden/helium-mcp
- **npm:** `helium-mcp`
- **Tools:** 9 tools, 50 free queries, no signup needed


Made with [Cursor](https://cursor.com)