### PR TITLE
Add Not Human Search and AI Dev Jobs to Search & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- Not Human Search — https://nothumansearch.ai/mcp — Agent-first search engine for discovering AI-accessible tools, MCP servers, and APIs across 1,400+ indexed sites.
+- AI Dev Jobs — https://aidevboard.com/mcp — Search 5,400+ AI developer job listings with salary data via MCP.
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---


### PR DESCRIPTION
## Summary

Adds two MCP servers to the Search & Web category:

- **Not Human Search** — Agent-first search engine indexing 1,400+ AI-accessible tools, MCP servers, and APIs. Remote MCP endpoint at https://nothumansearch.ai/mcp
- **AI Dev Jobs** — Search 5,400+ AI developer job listings with salary data via MCP. Endpoint at https://aidevboard.com/mcp

Both are production-ready and actively maintained.