### PR TITLE
Add VirtualSMS to Communication category

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- VirtualSMS — https://github.com/virtualsms-io/mcp-server
 
 ---
 


### PR DESCRIPTION
Adding the VirtualSMS MCP server to the Communication section.

VirtualSMS provides virtual phone numbers from real physical SIM cards (not VoIP) for SMS verification. AI agents use the 12 MCP tools to get numbers and receive OTP codes for WhatsApp, Telegram, Google, Instagram, Binance and 700+ services across 145+ countries.

**Repository:** https://github.com/virtualsms-io/mcp-server
**npm package:** `virtualsms-mcp`

**Already listed on:**
- punkpeye/awesome-mcp-servers
- TensorBlock/awesome-mcp-servers

**Affiliation:** I operate the VirtualSMS service — disclosed for transparency.