### PR TITLE
Add ph-civic-data-mcp (Philippine government data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- ph-civic-data-mcp (Philippine government data) — https://github.com/xmpuspus/ph-civic-data-mcp
 
 ---
 


### PR DESCRIPTION
Adds `ph-civic-data-mcp` to **Research & Data (🧬)**.

First MCP server for Philippine government open data — PHIVOLCS earthquakes + volcano alerts, PAGASA weather + typhoons, PhilGEPS procurement, PSA OpenSTAT (2020 Census + 2023 poverty), AQICN air quality. 12 tools including a cross-source multi-hazard risk profiler.

- Install: `uvx ph-civic-data-mcp`
- PyPI: https://pypi.org/project/ph-civic-data-mcp/
- Repo: https://github.com/xmpuspus/ph-civic-data-mcp
- License: MIT

Entry follows the section's minimalist `- Name — URL` format.