### PR TITLE
Add Helium MCP under Finance - ML option pricing + structured news bias scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- Helium (per-symbol ML option pricing with prob_ITM, daily-ranked long/short-vol strategies, 31-dim news bias scoring across 3.2M+ articles) — https://github.com/connerlambden/helium-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---


### PR DESCRIPTION
Adding [Helium MCP](https://github.com/connerlambden/helium-mcp) to the Finance category.

Free, open MCP server giving AI assistants:
- Per-symbol ML options pricing model (predicted fair value + prob_ITM)
- Daily-ranked long-vol/short-vol strategy screen with bull/bear cases comparing Helium IV vs market IV
- 31-dimension structured bias scoring across 3.2M+ articles from 5,000+ sources
- Balanced multi-source news synthesis with probability-weighted outcomes
- Real-time stock/ETF/crypto quotes

One-line setup: `npx mcp-remote https://heliumtrades.com/mcp` (free, no signup).

Thanks for considering!

Made with [Cursor](https://cursor.com)