### PR TITLE
Add AgentSeal to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- AgentSeal — https://github.com/JoeyBrar/agentseal-mcp — Action logs for AI agents. Records every action in a SHA-256 hash chain, for verifiable audit trails. Install via `npx agentseal-mcp`.
 
 ---
 


### PR DESCRIPTION
Adds [AgentSeal](https://github.com/JoeyBrar/agentseal-mcp) to the Security section.

AgentSeal is an MCP server that records every agent action in a SHA-256 hash chain, producing a verifiable audit trail for AI agents.

- Install: `npx agentseal-mcp`
- Runtime: Node.js (TypeScript), local stdio