### PR TITLE
Add unslop to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Developer-focused MCP servers and tools.
 - OpenRPC — https://github.com/shanejonas/openrpc
 - Postman — https://github.com/delano/postman-mcp-server
 - QA Sphere (⭐) — https://github.com/Hypersequent/qasphere-mcp
+- unslop — https://github.com/MohamedAbdallah-14/unslop
 - flutter-skill — https://github.com/ai-dashboad/flutter-skill — AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
 - marimo (⭐) — https://github.com/marimo-team/codemirror-mcp
 - Figma — https://github.com/GLips/Figma-Context-MCP


### PR DESCRIPTION
## Summary

Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the **Development Tools** category.

**What it does:** MCP server and CLI that removes named AI writing patterns from text. Targets tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode shows what would change without modifying the file. Five intensity levels.

**Why Development Tools:** Developer utility for cleaning AI-generated prose in commit messages, PR descriptions, documentation, and README files. Runs locally, no API keys, MIT licensed.
