### PR TITLE
Add VaultPilot to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- VaultPilot (Safety first. Hardware-verified DeFi for AI agents — designed for when the AI can be compromised. Read balances + DeFi positions across Ethereum / Arbitrum / Polygon / Base / TRON / Solana / Bitcoin and prepare transactions reviewed on a Ledger device; private keys never leave the hardware wallet.) — https://github.com/szhygulin/vaultpilot-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---


### PR DESCRIPTION
Submitting [VaultPilot](https://github.com/szhygulin/vaultpilot-mcp) (open-source MCP, MIT). Maintainer here.

Safety first. Hardware-verified DeFi for AI agents — designed for when the AI / MCP server / host computer can be compromised. The agent proposes, you approve on your Ledger; private keys never leave the hardware wallet.

Coverage:
- **EVM** (Ethereum / Arbitrum / Polygon / Base) — Aave V3, Compound V3, Morpho Blue, Uniswap V3 LP, Lido, EigenLayer, LiFi, 1inch
- **TRON** — TRX + TRC-20, Stake 2.0
- **Solana** — SOL + SPL, MarginFi, Kamino, Marinade / Jito / native staking, Jupiter v6
- **Bitcoin** — segwit + taproot sends, BIP-137 message signing

[npm](https://www.npmjs.com/package/vaultpilot-mcp) · [Source](https://github.com/szhygulin/vaultpilot-mcp) · [SECURITY.md](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md)