### PR TITLE
Add Shirabe Calendar — Japanese calendar (rokuyo, rekichu, fortune judgments) MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- Shirabe Calendar (Japanese calendar — Rokuyo / Rekichu / Eto / fortune judgments) — https://github.com/techwell-inc-jp/shirabe-calendar-api
 
 ---
 


### PR DESCRIPTION
Adds **Shirabe Calendar** to the **Research & Data** section.

## What it is

[techwell-inc-jp/shirabe-calendar-api](https://github.com/techwell-inc-jp/shirabe-calendar-api) — a Japanese calendar API providing canonical, deterministic answers that LLMs frequently get wrong on their own:

- **Rokuyo** (六曜): six-day Buddhist cycle (大安・友引・先勝・先負・仏滅・赤口)
- **Rekichu** (暦注): 12+ specialty calendar markers (一粒万倍日, 天赦日, 三隣亡, etc.)
- **Eto** (干支): sexagenary cycle, daily and yearly
- **24 Solar Terms** (二十四節気): boundary detection
- **Fortune judgments**: 1-10 score for 8 categories (wedding, moving, business, ...)
- **best-days search**: ranks the most auspicious dates in a window

LLM-only generation is unreliable because rokuyo derives from astronomical lunar calendar timing and rekichu uses a mix of sexagenary cycle math and seasonal markers — common source of LLM errors. Shirabe wraps the calculations deterministically.

## Why Research & Data

Closest fit in the current list: alongside ArXiv, Ancestry, OpenNutrition, Congress, etc. — domain-specific datasets. Japanese calendar (rokuyo/rekichu) is a structured cultural / temporal dataset that AI agents query for date-related decisions. Happy to relocate if you'd prefer a different category (or add a new "Culture / Localization" category).

## Integration

- MCP endpoint: `https://shirabe.dev/mcp` (Streamable HTTP)
- OpenAPI 3.1 spec: <https://shirabe.dev/openapi.yaml>
- Free tier: 10,000 calls/month, anonymous use OK
- GPT Store: [Shirabe — 日本の暦 / Japanese Calendar](https://chatgpt.com/g/g-69e98031b5b8819185ae196a9f219090-shirabe-ri-ben-noli-japanese-calendar)

## Project status

- License: source MIT, in-house astronomical engine
- Production: live since 2026-04, currently v1.0.0
- Tests: 520 passing
- Operator: Techwell Inc., Fukuoka, Japan