### PR TITLE
Add web3-docs to Category: Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Payments, market data, and finance tools.
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---
+- web3-docs — https://github.com/dioptx/web3-docs (local MCP server indexing 1,767 protocol proposals across 10 chains: EIPs, BIPs, ADRs, CIPs, RFCs; plus canonical contract addresses for 19 EVM protocols. Fork-aware: answers "what's in Cancun?" / "BIPs activated with Taproot?")
 
 ## Category: Research & Data (🧬)
 


### PR DESCRIPTION
Adds [**web3-docs**](https://github.com/dioptx/web3-docs) to **Category: Finance (💹)**.

A local MCP server with a searchable corpus of **1,767 protocol proposals across 10 chains** (EIPs, BIPs, ADRs, CIPs, RFCs) plus a **canonical contract-address registry covering 19 protocols** on major EVM chains. SQLite + FTS5, no API keys, works offline.

**Distinctive**: multi-chain by design; fork-aware (maps proposals to activation forks with consensus-layer aliases); three demo GIFs in the README. Install via `uvx --from git+https://github.com/dioptx/web3-docs web3-docs-mcp` — works with any MCP-compatible client (Claude Code, Cursor, Windsurf, Cline, Zed, Continue, Codex).