### PR TITLE
Add MyCarTracks MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Official integrations are maintained by companies building production-ready MCP 
 - Box — https://github.com/box-community/mcp-server-box (⭐)
 - Cloudflare — https://github.com/cloudflare/mcp-server-cloudflare (⭐)
 - GitHub — https://github.com/github/github-mcp-server (official)
+- MyCarTracks — https://mycartracks.com/resources/connect-with-ai
 - Notion — https://github.com/makenotion/notion-mcp (official)
 - Stripe — https://github.com/stripe/agent-toolkit/tree/main (⭐)
 - PayPal — https://github.com/paypal/agent-toolkit/tree/main (⭐)
@@ -323,6 +324,7 @@ Mapping and geolocation.
 - Google Maps — https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps
 - IPLocate — https://github.com/iplocate/mcp-server-iplocate
 - IP2Location.io — https://github.com/ip2location/mcp-ip2location-io
+- MyCarTracks — https://mycartracks.com/resources/connect-with-ai
 - QGIS — https://github.com/jjsantos01/qgis_mcp
 
 ---


### PR DESCRIPTION
Adds MyCarTracks to the Official Servers and Location Services sections.\n\nValidation before submission:\n- Checked code/README for MyCarTracks and mycartracks. No duplicate found.\n- Checked issues and PRs for MyCarTracks. No duplicate found.\n- Checked adjacent terms such as mileage, vehicle tracking, GPS, and fleet. No duplicate MyCarTracks entry found.\n- Verified the public listing page returns HTTP 200: https://mycartracks.com/resources/connect-with-ai\n- Verified the MCP endpoint is reachable and auth-protected at https://mycartracks.com/mcp.\n- Verified OAuth protected resource metadata at https://mycartracks.com/.well-known/oauth-protected-resource.