### PR TITLE
Add VirtualSMS — SMS verification MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- VirtualSMS — https://github.com/virtualsms-io/mcp-server (SMS verification with real physical SIM phone numbers across 145+ countries and 2500+ services — WhatsApp, Telegram, Discord, Gmail. Lets AI agents receive OTP codes, rent long-term numbers, and automate signup/verification flows. Also exposes x402 micropayments for agent-native billing.)
 
 ---
 


### PR DESCRIPTION
Adds VirtualSMS to Category: Communication.

- Repo: https://github.com/virtualsms-io/mcp-server
- Category: Communication (💬)
- What it does: SMS verification with real physical SIM phone numbers across 145+ countries and 2500+ services. Lets AI agents receive OTP codes, rent long-term numbers, and automate signup/verification flows. Also exposes x402 micropayments for agent-native billing.

Format follows the existing list convention ().