### PR TITLE
Add Gorilla under Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- Gorilla — https://github.com/opusforge/gorilla-mcp
 
 ---
 


### PR DESCRIPTION
Adds Gorilla under Marketing.

What it is: a lead-discovery server for solo SaaS founders. One run searches Reddit, X, YouTube, and TikTok in parallel and ranks each post by how close someone is to buying. The agent-side tools (`leads.find`, `outreach.draft`, `outreach.plan`) let Claude follow up the search with drafts and a Week-1 plan, not just dump a CSV.

Hosted, paid per run. $0.99 / $3.99 weekly / $149.99 lifetime. Sign up at https://usegorilla.app.

Install: `npx -y github:opusforge/gorilla-mcp`
Repo: https://github.com/opusforge/gorilla-mcp