### PR TITLE
feat: add kc-agent (KubeStellar Console) to Kubernetes MCP implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Personal knowledge and notes integrations.
 Cloud vendors and orchestration.
 
 - Cloudflare (⭐) — https://github.com/cloudflare/mcp-server-cloudflare
-- Kubernetes (multiple implementations) — https://github.com/strowk/mcp-k8s-go (1), https://github.com/weibaohui/k8m (2), https://github.com/StacklokLabs/mkp (3)
+- Kubernetes (multiple implementations) — https://github.com/strowk/mcp-k8s-go (1), https://github.com/weibaohui/k8m (2), https://github.com/StacklokLabs/mkp (3), https://github.com/kubestellar/console (4 — kc-agent: AI-powered multi-cluster MCP bridge with 20+ CNCF integrations)
 - Tinybird (⭐) — https://github.com/tinybirdco/mcp-tinybird
 - Google Cloud Run — https://github.com/GoogleCloudPlatform/cloud-run-mcp
 - Render — https://render.com/docs/mcp-server


### PR DESCRIPTION
## Summary

Adds [kc-agent](https://github.com/kubestellar/console) — the Kubernetes MCP bridge component of KubeStellar Console — to the existing Kubernetes implementations entry in the Cloud Platforms category.

**What is kc-agent?**
- A local agent that bridges AI models (Claude, OpenAI, Gemini) to multi-cluster Kubernetes environments via MCP
- Exposes Kubernetes resources (pods, nodes, namespaces, deployments, etc.) to AI assistants through the Model Context Protocol
- Supports 20+ CNCF integrations: ArgoCD, Kyverno, Prometheus, Grafana, Istio, Flux, Falco, OPA/Gatekeeper, and more
- Part of [KubeStellar Console](https://console.kubestellar.io) — open-source, MIT-licensed

**Why it fits here:** kc-agent is a Kubernetes-native MCP server that allows AI agents to query and manage multi-cluster Kubernetes environments via natural language. It complements the existing implementations (mcp-k8s-go, k8m, mkp) with its focus on multi-cluster + AI agent workflows.