### PR TITLE
Add BuyWhere MCP Server to E-Commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Commerce and marketplace integrations.
 - Mercado Libre — https://mcp.mercadolibre.com/
 - Gunsnation — https://github.com/DynamicDeals/mcp-server-gunsnation
 - ShopSavvy (⭐) — https://github.com/shopsavvy/shopsavvy-mcp-server
+- BuyWhere MCP Server — https://github.com/BuyWhere/buywhere-mcp - Cross-border product catalog for AI agents. Search and compare products from Singapore, SEA, and US markets.
 
 ---
 


### PR DESCRIPTION
Add **BuyWhere MCP Server** — cross-border e-commerce product catalog for AI agents.

- **GitHub**: https://github.com/BuyWhere/buywhere-mcp
- **npm**: https://www.npmjs.com/package/buywhere-mcp
- **Category**: E-Commerce
- **License**: MIT

Product search, cross-border matching, price history, and merchant discovery for Singapore, SEA, and US markets via Model Context Protocol.