### PR TITLE
Add BuyWhere MCP Server to E-Commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ Books, libraries, and creative tools.
 
 Commerce and marketplace integrations.
 
+- BuyWhere — https://github.com/BuyWhere/buywhere-mcp
 - Mercado Libre — https://mcp.mercadolibre.com/
 - Gunsnation — https://github.com/DynamicDeals/mcp-server-gunsnation
 - ShopSavvy (⭐) — https://github.com/shopsavvy/shopsavvy-mcp-server


### PR DESCRIPTION
## Summary
Add [BuyWhere MCP Server](https://github.com/BuyWhere/buywhere-mcp) to the E-Commerce (🛒) section.

BuyWhere is a cross-border e-commerce product catalog for AI agents. Search 3M+ products across Singapore, SEA, and US markets with price comparison and deal discovery. Published as `@buywhere/mcp-server`.

## Checklist
- [x] Placed in correct alphabetical order (B before G)
- [x] Matches existing entry format (Name — URL)
- [x] Only added to the E-Commerce section