### PR TITLE
Add OpenAgent to AI Services category

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ AI model & ML service integrations.
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI Compatible Chat — https://github.com/pyroprompts/any-chat-completions-mcp
+- OpenAgent — https://github.com/the-open-agent/openagent — Open-source personal AI assistant with LLM, RAG, agent loops, browser-use, shell execution, and MCP tool integration
 - Perplexity — https://github.com/tanigami/mcp-server-perplexity
 - LlamaCloud — https://github.com/run-llama/mcp-server-llamacloud
 - HuggingFace Spaces — https://github.com/evalstate/mcp-hfspace

--- a/README_ja.md
+++ b/README_ja.md
@@ -437,6 +437,7 @@ AI モデルおよび ML サービスとの統合。
 - Agentset AI — https://github.com/agentset-ai/mcp-server
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI 互換のチャット — https://github.com/pyroprompts/any-chat-completions-mcp
+- OpenAgent — https://github.com/the-open-agent/openagent — オープンソースのパーソナル AI アシスタント。LLM、RAG、エージェントループ、ブラウザ自動化、シェル実行、MCP ツール統合をサポート
 - Perplexity — https://github.com/tanigami/mcp-server-perplexity
 - LlamaCloud — https://github.com/run-llama/mcp-server-llamacloud
 - HuggingFace Spaces — https://github.com/evalstate/mcp-hfspace

--- a/README_ko.md
+++ b/README_ko.md
@@ -334,6 +334,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 ## 카테고리: AI 서비스 (🤝)
 
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
+- OpenAgent — https://github.com/the-open-agent/openagent — 오픈소스 개인 AI 어시스턴트. LLM, RAG, 에이전트 루프, 브라우저 자동화, 셸 실행, MCP 도구 통합 지원
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -426,6 +426,7 @@ Shell、操作系统与任务自动化相关。
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI 兼容 Chat — https://github.com/pyroprompts/any-chat-completions-mcp
+- OpenAgent — https://github.com/the-open-agent/openagent — 开源个人 AI 助手，支持 LLM、RAG、智能体循环、浏览器自动化、命令行执行与 MCP 工具集成
 - Perplexity — https://github.com/tanigami/mcp-server-perplexity
 - LlamaCloud — https://github.com/run-llama/mcp-server-llamacloud
 - HuggingFace Spaces — https://github.com/evalstate/mcp-hfspace

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -440,6 +440,7 @@ AI 與機器學習服務整合：
 - Agentset AI — https://github.com/agentset-ai/mcp-server
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI 相容 Chat — https://github.com/pyroprompts/any-chat-completions-mcp
+- OpenAgent — https://github.com/the-open-agent/openagent — 開源個人 AI 助理，支援 LLM、RAG、Agent 迴圈、瀏覽器自動化、命令列執行與 MCP 工具整合
 - Perplexity — https://github.com/tanigami/mcp-server-perplexity
 - LlamaCloud — https://github.com/run-llama/mcp-server-llamacloud
 - HuggingFace Spaces — https://github.com/evalstate/mcp-hfspace


### PR DESCRIPTION
This PR adds [OpenAgent](https://github.com/the-open-agent/openagent) to the **AI Services** category across all supported language versions of the README.

**About OpenAgent:**
- Open-source personal AI assistant powered by LLM, RAG, and autonomous agent loops
- Supports MCP (Model Context Protocol) integration via SSE, Stdio, and StreamableHTTP
- Features include browser-use automation, shell execution, office automation, web search, and visual workflow builder
- Supports 30+ model providers (OpenAI, Claude, Gemini, DeepSeek, etc.)
- Self-hostable platform with admin dashboard, SSO, multi-tenancy, and REST API
- Licensed under Apache-2.0

**Changes:**
- Added OpenAgent entry to `README.md` (English)
- Added OpenAgent entry to `README_zh_CN.md` (Simplified Chinese)
- Added OpenAgent entry to `README_zh_TW.md` (Traditional Chinese)
- Added OpenAgent entry to `README_ja.md` (Japanese)
- Added OpenAgent entry to `README_ko.md` (Korean)

**Checklist:**
- [x] Project is actively maintained
- [x] Project supports MCP protocol
- [x] Clear README and documentation available
- [x] Added to appropriate category (AI Services)
- [x] Updated all language versions consistently