### PR TITLE
Add Nylas CLI under Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Nylas CLI — https://github.com/nylas/cli
 
 ---
 


### PR DESCRIPTION
Adds Nylas CLI to the Communication category.

**What it is:** MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP behind one auth flow.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com