### PR TITLE
Add agentprobe to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- agentprobe — https://agentprobe.fly.dev — Probes any seller URL for agentic commerce readiness. Returns score and grade (NOT_READY/PARTIAL/AGENT_READY/CERTIFIED) across 13 checks: llms.txt, OpenAPI, MCP endpoint, payment rails, fulfillment proof. One MCP tool: probe_site(url). CI action available.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
Adds [agentprobe](https://agentprobe.fly.dev) to the Development Tools category.

agentprobe probes any seller URL for agentic commerce readiness. Returns a score and grade (NOT_READY / PARTIAL / AGENT_READY / CERTIFIED) across 13 checks: llms.txt, OpenAPI, ai-plugin.json, MCP endpoint, commerce.json, catalog/quote/checkout APIs, payment rail declarations, unsupported-rail declaration, no-fake-claims check, and fulfillment proof.

One MCP tool: `probe_site(url)`. Remote MCP at `agentprobe.fly.dev/mcp`, no auth required. CI GitHub Action available. Useful for developers building or auditing agentic commerce integrations.