### PR TITLE
Add UniRate MCP server to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- UniRate (currency conversion across 170+ fiat and crypto pairs with daily historical rates back to 1999; tools: convert, latest_rate, historical_rate, list_currencies) — https://github.com/UniRate-API/unirate-mcp
 
 ---
 


### PR DESCRIPTION
Adds UniRate to **Category: Finance (💹)**.

UniRate (currency conversion across 170+ fiat and crypto pairs with daily historical rates back to 1999) — https://github.com/UniRate-API/unirate-mcp

Four tools: `convert`, `latest_rate`, `historical_rate`, `list_currencies`. Stdio + Streamable HTTP / SSE transports. Single npm install: `npx @unirate/mcp`.

**Disclosure**

I run [UniRateAPI](https://unirateapi.com) and built `unirate-mcp` as the Pro-grade companion. Free tier covers `convert` / `latest_rate` / `list_currencies`; `historical_rate` requires a Pro key. PR was prepared with AI assistance (Claude Code).
