### PR TITLE
Add companion-memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- companion-memory — https://github.com/zhyue365/companion-memory (Local-first relationship memory for Codex personas and long-running AI companions. MCP stdio tools for persona and memory operations, SQLite + FTS5/vector recall, sensitive recall opt-in, and dry-run forgetting.)
 
 ---
 


### PR DESCRIPTION
Adds companion-memory to the Note Taking / memory-related section.\n\ncompanion-memory is a local-first relationship memory MCP server and Codex plugin bundle. It provides stdio MCP tools for persona management and memory save/search/list/export/forget flows, backed by SQLite with FTS5 and lightweight local vector recall. Sensitive memories are opt-in, and forgetting uses dry-run previews plus soft delete.