### PR TITLE
Add jpcite / autonomath-mcp under Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- jpcite / autonomath-mcp (Japanese public-program evidence: 11,601 subsidy/loan/tax/certification programs + 9,484 e-Gov laws + 22,258 enforcement detail rows + 13,801 国税庁 invoice registrants + 503,930 corporate entities + 6.12M facts; 139 tools, stdio, every packet ships `source_url` + `source_fetched_at` + `known_gaps`; 3 req/day per IP free, metered ¥3/billable unit) — https://github.com/shigetosidumeda-cyber/autonomath-mcp
 
 ---
 


### PR DESCRIPTION
Adds **jpcite** (`autonomath-mcp` on PyPI) under **Category: Research & Data (🧬)** — sits alongside Congress (legislative data) since the server is government / legal corpus.

## What is it

Japanese public-program evidence MCP server (139 tools, stdio, MCP 2025-06-18).

- 11,601 subsidies / loans / tax measures / certifications
- 9,484 e-Gov laws + 22,258 enforcement detail rows
- 13,801 国税庁 invoice registrants (PDL v1.0)
- 503,930 corporate entities + 6.12M facts
- Every packet ships `source_url`, `source_fetched_at`, `known_gaps`

## Pricing

- 3 req/day per IP free (anonymous tier)
- ¥3 per billable unit metered (税込 ¥3.30), no SKU tiers

## Install

```bash
uvx autonomath-mcp
```

## Registry status

Active on the official MCP Registry: `io.github.shigetosidumeda-cyber/autonomath-mcp` v0.3.4.

## Maintainer

Bookyou株式会社 (T8010001213708), info@bookyou.net.