### PR TITLE
feat: add benbencodes/llm-prices — MCP server for LLM API pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- llm-prices — https://github.com/benbencodes/llm-prices (LLM API pricing: query, compare, and calculate costs across 128 models and 22 providers. 6 MCP tools: get pricing, calculate cost, compare models, find cheapest, list providers, search models.)
 
 ---
 


### PR DESCRIPTION
## Summary

**[llm-prices](https://github.com/benbencodes/llm-prices)** is a zero-dependency Python CLI and MCP server for looking up and comparing LLM API pricing across 128 models from 22 providers (OpenAI, Anthropic, Google, Mistral, Groq, DeepSeek, xAI, and more).

### MCP tools provided

| Tool | Description |
|------|-------------|
| `get_model_pricing` | Get pricing for a specific model |
| `calculate_api_cost` | Calculate exact cost for input + output token counts |
| `compare_models` | Compare cost across multiple models side by side |
| `find_cheapest_models` | Find the N cheapest models for your workload |
| `list_providers` | List all 22 providers with min pricing |
| `search_llm_models` | Search models by name or filter by provider |

### Install

```bash
pip install "git+https://github.com/benbencodes/llm-prices[mcp]"
```

### Claude Desktop config

```json
{
  "mcpServers": {
    "llm-prices": { "command": "llm-prices-mcp" }
  }
}
```

MIT license · 128 models · 22 providers · zero dependencies for core CLI
