### PR TITLE
Add tensorfeed-x402-base-mcp to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- tensorfeed-x402-base-mcp (read-only Base mainnet chain reader; verify x402 payment settlements on-chain, parse /.well-known/x402 manifests, list USDC payments, check AFTA federation; 11 tools, no private keys, MIT) — https://github.com/RipperMercs/tensorfeed-x402-base-mcp
 
 ---
 


### PR DESCRIPTION
Adds [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) right after the awesome-x402 entry in the Finance category.

Read-only Base mainnet chain reader for x402 payment verification. 11 tools: verify on-chain that a USDC settlement matches a claimed x402 receipt, parse publisher `/.well-known/x402` manifests, list recent USDC payments, check AFTA federation status, plus generic Base reads.

No private keys, no signing, no broadcasts. MIT. Listed in the canonical MCP registry as `ai.tensorfeed/x402-base-mcp`.