### PR TITLE
Add Dakera to agent memory MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- Dakera — https://github.com/dakera-ai/dakera-mcp (Self-hosted MCP-native agent memory server. 83 tools for persistent, decay-weighted episodic memory. RocksDB+HNSW, 87.8% LoCoMo benchmark, multi-SDK support. Docker Compose deployment.)
 
 ---
 


### PR DESCRIPTION
## Dakera MCP

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted, MCP-native agent memory server.

Adding to the Note Taking / memory section alongside OMEGA since both are persistent MCP-based memory solutions.

**What it does:**
- 83 MCP tools for storing, recalling, and managing agent episodic memories
- Decay-weighted retrieval: memories fade naturally over time, preventing stale context
- Self-hosted, all data on your infrastructure — no cloud API
- RocksDB + HNSW vector search, 87.8% LoCoMo benchmark
- Multi-SDK: Python, JavaScript, Rust, Go

**Differentiation from OMEGA:**
- Production-grade server architecture vs single-agent tool
- Explicit namespace management for multi-agent/multi-project isolation
- Richer MCP toolset (83 tools vs 12)