### PR TITLE
Add Ejentum under AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- Ejentum — https://github.com/ejentum/ejentum-mcp
 
 ---
 


### PR DESCRIPTION
Adds `Ejentum` under **AI Services**, after `ZenML` (matching the section's add-order convention).

MCP server (npm `ejentum-mcp` for stdio, or remote HTTPS at `https://api.ejentum.com/mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained, listed on Official MCP Registry as `io.github.ejentum/ejentum-mcp`
- One line added under AI Services
- Not a duplicate

Maintainer is me; happy to address review feedback.