### PR TITLE
Add CN Calendar Skill: Chinese Calendar and Holiday MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Automation platforms and workflow tools.
 - Taskade (⭐) — https://github.com/taskade/mcp
 - Zapier — https://zapier.com/mcp
 - Pipedream — https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol
+- CN Calendar Skill — https://github.com/demo112/cn-calendar-skill
 - Tool aggregators like Rube, Rube/Composio and MCPJungle are listed in Aggregators.
 
 ---


### PR DESCRIPTION
Chinese calendar MCP server with 13 endpoints: holidays, lunar/solar conversion, 24 solar terms, workday calculation, leave bridge planning. Zero API dependencies. Category: Workflow Automation. Repo: https://github.com/demo112/cn-calendar-skill