### PR TITLE
Add Dakera: self-hosted MCP agent memory server with hybrid vector storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Access to cloud storage platforms.
 
 Database access with schema inspection and query capabilities.
 
+- Dakera — https://github.com/Dakera-AI/dakera (Self-hosted agent memory server with hybrid BM25 + HNSW vector retrieval, decay-weighted recall, multi-agent namespacing, and MCP integration)
 - PostgreSQL — https://github.com/modelcontextprotocol/servers/tree/main/src/postgres
 - SQLite — https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite
 - DuckDB — https://github.com/ktanaka101/mcp-server-duckdb


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/Dakera-AI/dakera) to the **Databases** section.

Dakera is a self-hosted agent memory server built on hybrid BM25 + HNSW vector storage:
- Persistent memory storage with hybrid BM25 + HNSW vector retrieval
- Decay-weighted recall — memories fade with time, like human memory
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration for Claude Code, Cursor, and Windsurf
- SDKs for Python, TypeScript, Go, and Rust
