### PR TITLE
Add Certvo MCP server to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,3 +696,7 @@ If this project is helpful for you, please cite:
       howpublished = {\url{https://github.com/YuzeHao2023/Awesome-MCP-Servers}},
 }
 ```
+
+## Category: Development Tools
+- [Certvo](https://certvo.com/docs/mcp) ☁️ - Accessibility scanning (WCAG 2.1 A/AA/AAA via Playwright + axe-core), AI code-fix generation, alt text, and VPAT 2.4 over MCP. `claude mcp add --transport http certvo https://certvo.com/api/mcp/`
+


### PR DESCRIPTION
Hi! Submitting Certvo's MCP server for the Development Tools section.

Certvo exposes an HTTP MCP server at https://certvo.com/api/mcp/ with tools for:
- WCAG 2.1 A/AA/AAA accessibility scanning (Playwright + axe-core)
- AI-powered code fix generation (returns patched HTML/CSS/JS using Claude AI)
- Alt text generation for images
- VPAT 2.4 report generation

Add to Claude Code or Claude Desktop:
```
claude mcp add --transport http certvo https://certvo.com/api/mcp/
```

- Free tier: anonymous scans + 10 AI fixes/month
- Docs: https://certvo.com/docs/mcp

Happy to revise the description or move to a different section if needed.