### PR TITLE
Add Sharpe MCP Server to finance MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Payments, market data, and finance tools.
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
+- Sharpe MCP Server — https://www.sharpe.ai/docs/mcp-server (agent-ready crypto market intelligence for funding rates, futures, options, arbitrage, narratives, and exchange listings)
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit


### PR DESCRIPTION
Summary
- Adds Sharpe MCP Server to the Finance category.
- Keeps the entry in the repository's compact single-line format.

Why this belongs here
The list groups MCP servers by the domain they expose to agents. Sharpe MCP Server gives agents crypto market intelligence across funding rates, futures, options, arbitrage, narratives, and exchange listings, so Finance is the correct category.

Verification
- Checked the MCP docs on 2026-05-14: https://www.sharpe.ai/docs/mcp-server
- Ran git diff --check.
- Searched open and closed PRs and issues for Sharpe before submitting.

Disclosure
I am affiliated with Sharpe.
