### PR TITLE
Add Dakera: self-hosted MCP agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Access to cloud storage platforms.
 
 Database access with schema inspection and query capabilities.
 
+- Dakera — https://github.com/dakera-ai/dakera-deploy (Self-hosted agent memory server with hybrid BM25 + HNSW vector retrieval, decay-weighted recall, multi-agent namespacing, and MCP integration)
 - PostgreSQL — https://github.com/modelcontextprotocol/servers/tree/main/src/postgres
 - SQLite — https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite
 - DuckDB — https://github.com/ktanaka101/mcp-server-duckdb


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
