### PR TITLE
Add ModelForge — bulge-tier financial model factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
+- ModelForge (⭐) — https://github.com/Whatsonyourmind/modelforge (bulge-tier financial model factory: spec → live-formula Excel for LBO/DCF/M&A/IPO/restructuring/project finance/NPL/structured credit; source-traceable cells; 7-jurisdiction tax pack IT/US/UK/DE/FR/ES/JP)
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server


### PR DESCRIPTION
Adds [Whatsonyourmind/modelforge](https://github.com/Whatsonyourmind/modelforge) to the Finance category.

Bulge-tier Excel financial model factory. 14 templates (LBO, DCF, M&A, IPO, restructuring, project finance, NPL, structured credit, 3-statement, sponsor LBO, fairness, credit memo, real estate, minibond). 7 jurisdictions tax pack. Every cell live-formulated, every number source-traced via SQLite linkage graph.

`pip install modelforge-finance[mcp]`

- PyPI: https://pypi.org/project/modelforge-finance/
- MCP registry: `io.github.Whatsonyourmind/modelforge` (isLatest)
- 431/431 tests · 10 MCP tools