### PR TITLE
Add Ethora MCP server to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Ethora — https://github.com/dappros/ethora-mcp-server
 
 ---
 


### PR DESCRIPTION
Adds `Ethora` ([@ethora/mcp-server](https://github.com/dappros/ethora-mcp-server)) under **Category: Communication (💬)**.

Official MCP server for [Ethora](https://github.com/dappros/ethora), an open-source chat & messaging platform. Lets MCP clients (Claude, Cursor, VS Code, Cline, Windsurf) manage chat apps, deploy AI agents / chatbots with RAG, broadcast messages, and run B2B workflows.

- Repo: https://github.com/dappros/ethora-mcp-server
- npm: `@ethora/mcp-server`
- Official MCP Registry: `io.github.dappros/ethora-mcp-server`
- MIT licensed