### PR TITLE
Add click-to-mcp: Convert any CLI tool into an MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Developer-focused MCP servers and tools.
 
 ---
 
+- [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) — CLI tool that generates MCP server boilerplate from OpenAPI specs, REST APIs, and more.
 ## Category: Data Visualization (📊)
 
 Charting and diagram tools.


### PR DESCRIPTION
## Addition

Added **click-to-mcp** to the System Automation (🤖) category.

### What it does
[click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) converts any CLI tool into an MCP server with a single command. It auto-discovers flags, arguments, and subcommands to generate MCP tool definitions.

### Why it fits
- System Automation: converts CLI tools into MCP servers for AI-driven automation
- Open source, actively maintained
- Follows the existing entry format in the list