### PR TITLE
Add CoinPaprika to Finance, fix DexPaprika URL to official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,9 @@ Payments, market data, and finance tools.
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
+- CoinPaprika (⭐) — https://github.com/coinpaprika/coinpaprika-mcp
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
-- DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
+- DexPaprika (⭐) — https://github.com/coinpaprika/dexpaprika-mcp
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit


### PR DESCRIPTION
Two small Finance section updates.

**1. Add CoinPaprika MCP**

CoinPaprika is a REST market data API for centralized exchanges: prices, tickers, OHLCV, exchanges, historical data. The MCP server is hosted at `mcp.coinpaprika.com`, so for most agent setups no install is needed. Source at `coinpaprika/coinpaprika-mcp`, MIT licensed.

This sits next to CoinMarket and DexPaprika in Finance and gives the list CEX market data coverage to pair with the DEX side that DexPaprika handles.

**2. Fix DexPaprika URL**

The current DexPaprika entry links to `donbagger/dexpaprika-mcp-server`, which is my personal fork from when I was prototyping. The maintained repo lives under the CoinPaprika org at `coinpaprika/dexpaprika-mcp`. Same package on npm (`dexpaprika-mcp`), but the org repo gets the releases and issue traffic.

Happy to split into two PRs if that's preferred.