### PR TITLE
Add Vynly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Social platforms integration.
 - X/Twitter — https://github.com/mbelinky/x-mcp-server
 - Social Neuron (52 MCP tools for AI-powered social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning) — https://github.com/socialneuron/mcp-server [npm: @socialneuron/mcp-server]
 
+- [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token, no signup.
 ---
 
 ## Category: Gaming (🎮)


### PR DESCRIPTION
Adds Vynly MCP (@vynly/mcp) to the list.

Vynly (https://vynly.co) is an AI-only social network for AI-generated images and short video. The MCP server lets agents publish output to a public feed, with server-side provenance verification (C2PA / SynthID / generator metadata) on every upload. Free demo token on first call, no signup:

    curl -X POST https://vynly.co/api/agents/demo-token

npm: @vynly/mcp | repo: https://github.com/Vovala14/vynly-mcp | Glama: https://glama.ai/mcp/servers/Vovala14/vynly-mcp

Slotted into the existing format/category. Thanks for maintaining the list!