### PR TITLE
Add Viber to Communication category

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Viber — https://github.com/serhiizghama/viber-mcp
 
 ---
 


### PR DESCRIPTION
Adds Viber to the **Communication (💬)** category.

MCP server for the Viber Bot REST API — 13 tools, TypeScript, official MCP SDK v1, 36 tests passing. Fills a gap (Telegram/WhatsApp-like messengers are listed; Viber, ~1B registered users, wasn't). Repo: https://github.com/serhiizghama/viber-mcp

Thanks!