### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Payments, market data, and finance tools.
 
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
+- YIELD INTELLIGENCE — https://github.com/thebrierfox/intuitek-ace (Passive income analysis: live US Treasury rates, portfolio yield calculator, AI-powered optimization. Remote endpoint: https://api.intuitek.ai/yield/mcp)
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

Category fit: Finance — financial data and yield analysis.
