### PR TITLE
Add cargoffer MCP servers to Location Services 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,9 @@ Mapping and geolocation.
 - IPLocate — https://github.com/iplocate/mcp-server-iplocate
 - IP2Location.io — https://github.com/ip2location/mcp-ip2location-io
 - QGIS — https://github.com/jjsantos01/qgis_mcp
+- bolsa_de_carga-mcp — https://github.com/cargoffer/bolsa_de_carga-mcp
+- ecmr-mcp — https://github.com/cargoffer/ecmr-mcp
+- transcend-mcp-server — https://github.com/cargoffer/transcend-mcp-server
 
 ---
 


### PR DESCRIPTION
Adding 3 MCP servers from Cargoffer to the Location Services category:

- bolsa_de_carga-mcp — Freight marketplace / load board MCP server
- ecmr-mcp — Electronic consignment note (eCMR) MCP server
- transcend-mcp-server — AI-powered route optimization MCP server for heavy vehicles

All servers are open-source (MIT), listed on Glama, and production-ready.