### PR TITLE
Add brain.md to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- brain.md — https://github.com/mi4uu/brain.md (Local-first markdown vault with a built-in MCP server. 16 tools + 2 resources for read/write/search/tasks plus semantic helpers — `find_related`, `semantic_outline`, `context_for_query` (token-budgeted chunk packing), `find_orphans`, `weekly_digest`, `compare_notes`. Per-folder agent permissions, embedded WASM ONNX RAG (zero native deps), single Bun binary for macOS/Linux/Windows. AGPL-3.0.)
 
 ---
 


### PR DESCRIPTION
Adds [brain.md](https://github.com/mi4uu/brain.md) to **Category: Note Taking (📝)**.

**What it is**: Local-first markdown vault with a built-in MCP server. 16 tools + 2 resources for read/write/search/tasks plus semantic helpers (`find_related`, `semantic_outline`, `context_for_query` token-budgeted chunk packing, `find_orphans`, `weekly_digest`, `compare_notes`). Per-folder agent permissions, embedded WASM ONNX RAG (zero native deps), single Bun binary for macOS / Linux / Windows.

**Why this section**: it's exactly "personal knowledge and notes integration" — a markdown vault that an MCP client (Claude Desktop, Claude Code, Cursor, etc.) reads/searches/writes. Directly comparable to the existing Obsidian, Notion, Apple Notes, Slite and Google Keep entries.

**License**: AGPL-3.0-or-later
**Repo**: https://github.com/mi4uu/brain.md
**Glama**: https://glama.ai/mcp/servers/mi4uu/brain.md (already listed)