### PR TITLE
Add Wenlan MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
-- Origin — https://github.com/7xuanlu/origin (Local-first AI work memory. Captures decisions, handoffs, and project context, then serves source-backed wiki pages, graph context, and hybrid retrieval across MCP clients.)
+- Wenlan — https://github.com/7xuanlu/wenlan (Local-first AI knowledge base and LLM wiki. Captures decisions and project context, then serves source-cited wiki pages, graph context, and hybrid retrieval across MCP clients.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
-- Origin — https://github.com/7xuanlu/origin (Local-first memory layer for AI work. Captures decisions, handoffs, and project context, then serves source-backed recall, distilled Markdown pages, graph context, and hybrid retrieval across MCP clients.)
+- Origin — https://github.com/7xuanlu/origin (Local-first AI work memory. Captures decisions, handoffs, and project context, then serves source-backed wiki pages, graph context, and hybrid retrieval across MCP clients.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- Origin — https://github.com/7xuanlu/origin (Local-first memory layer for AI work. Captures decisions, handoffs, and project context, then serves source-backed recall, distilled Markdown pages, graph context, and hybrid retrieval across MCP clients.)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Wenlan to the Note Taking category, updating the existing submission from its pre-Wenlan name and repository.

Wenlan is a local-first AI knowledge base and LLM wiki with source-cited pages, capture, handoff, graph context, and hybrid retrieval across MCP clients.

Repository: https://github.com/7xuanlu/wenlan

Website: https://wenlan.app

Disclosure: I maintain Wenlan.
