### PR TITLE
Add bosslesss/inference-labs-mcp to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Developer-focused MCP servers and tools.
 - Mastra/mcp (⭐) — https://github.com/mastra-ai/mastra/tree/main/packages/mcp
 - Bucket — https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/cli#model-context-protocol
 - DefangLabs/defang — https://github.com/DefangLabs/defang
+- bosslesss/inference-labs-mcp — https://github.com/bosslesss/inference-labs-mcp — Vendor-neutral LLM routing and model comparison MCP server across OpenAI/Azure, Anthropic, Google, and Bedrock. Includes auth-free pricing/recommendation tools and authenticated routing/comparison tools.
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
 - many others in Community Servers and Official Servers


### PR DESCRIPTION
Hi! This PR adds [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) to **Category: Development Tools (💻)**.

Fit rationale:

- Developer-focused MCP server for model routing and comparison workflows.
- Works across major providers (OpenAI/Azure, Anthropic, Google, Bedrock).
- Provides two auth-free utility tools (`get_pricing`, `recommend_model`) plus two authenticated execution tools (`route_request`, `compare_models`).

Happy to adjust wording/placement if you prefer.