### PR TITLE
Add Tuning Engines governed runtime MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Identity and access management.
 
 Single MCP endpoints that expose many integrations.
 
+- Tuning Engines — https://github.com/cerebrixos-org/tuning-engines-cli — Govern model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 - SkillBoss — https://github.com/heeyo-life/skillboss-mcp — One API key for 100+ AI services (Claude, GPT, Gemini, DeepSeek, images, video, data scraping, payments, email, and more). OpenAI-compatible. Works in Claude Code, Cursor, Windsurf.
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev


### PR DESCRIPTION
Thank you for maintaining the multilingual MCP directory and its security guidance. This adds Tuning Engines under Aggregators because it exposes a tenant-scoped MCP endpoint around model, agent, skill, and MCP workflows while applying policy controls, approvals, traces, and usage analytics. The listing links the public source repository and includes the copy-paste `npx` install command.