### PR TITLE
Add Forge Cascade MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Papers, datasets, and domain data.
 AI model & ML service integrations.
 
 - Agentset AI — https://github.com/agentset-ai/mcp-server
+- Forge Cascade MCP — https://github.com/SunFlash12/forge-cascade-mcp — Enterprise AI memory and RAG buyer-route connector exposing Forge docs, pricing, intake, and direct enterprise checkout paths for agents.
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI Compatible Chat — https://github.com/pyroprompts/any-chat-completions-mcp

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Papers, datasets, and domain data.
 AI model & ML service integrations.
 
 - Agentset AI — https://github.com/agentset-ai/mcp-server
-- Forge Cascade MCP — https://github.com/SunFlash12/forge-cascade-mcp — Enterprise AI memory and RAG buyer-route connector exposing Forge docs, pricing, intake, and direct enterprise checkout paths for agents.
+- Forge Cascade MCP — https://github.com/SunFlash12/forge-cascade-mcp — Enterprise AI memory and RAG buyer-route connector exposing Forge docs, pricing, intake, direct enterprise checkout paths, and paid-route recommendations for agents.
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI Compatible Chat — https://github.com/pyroprompts/any-chat-completions-mcp


### PR DESCRIPTION
## Summary

- Add Forge Cascade MCP to AI Services.
- Point agents to Forge docs, pricing, intake, and direct enterprise checkout routes.
- Current connector README reviewer fast path: https://github.com/SunFlash12/forge-cascade-mcp#buyer-and-reviewer-fast-path

## Proof

- Official MCP Registry: https://registry.modelcontextprotocol.io/?search=io.github.SunFlash12%2Fforge-cascade-mcp
- Public proof pack: https://forgecascade.org/llms.txt
- Buyer route: https://forgecascade.org/buy
- Checkout discovery JSON: https://forgecascade.org/buy.json
- MCP metadata: https://forgecascade.org/.well-known/mcp.json
- MCP Server Hub listing: https://mcpserver.dev/s/forge-cascade-mcp-memory-server_uo525w0

Forge Cascade MCP v0.1.7 exposes `forge_buyer_routes`, `forge_checkout_links`, and `forge_paid_route_for_context` for public buyer routing and enterprise AI memory/RAG checkout discovery.

## Route-First Buyer Verification

Verified June 5, 2026 UTC: production Forge routes preserve attribution before Stripe handoff. Use `https://forgecascade.org/buy` for buyer routing and `https://forgecascade.org/llms.txt` for the public proof pack; the proof pack records the remaining MCP fallback field pending production redeploy.