### PR TITLE
Add UnifAPI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Web fetching, scraping, and search.
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
+- UnifAPI — https://github.com/unifapi-agent/unifapi-mcp-server - Hosted remote MCP server for public data across social, search, scraping, news, creator research, and KOL pricing workflows.
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch (SearXNG) — https://github.com/mnhlt/WebSearch-MCP and https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser

--- a/README_ja.md
+++ b/README_ja.md
@@ -301,6 +301,7 @@ Web フェッチ、スクレイピング、検索。
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
+- UnifAPI — https://github.com/unifapi-agent/unifapi-mcp-server - ソーシャル、検索、スクレイピング、ニュース、クリエイター調査、KOL価格推定などの公開データワークフロー向けホスト型リモートMCPサーバー。
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch (SearXNG) — https://github.com/mnhlt/WebSearch-MCP and https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser

--- a/README_ko.md
+++ b/README_ko.md
@@ -264,6 +264,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 - Puppeteer — https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer
 - Brave Search — https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search
 - Bright Data — https://github.com/luminati-io/brightdata-mcp
+- UnifAPI — https://github.com/unifapi-agent/unifapi-mcp-server - 소셜, 검색, 스크래핑, 뉴스, 크리에이터 리서치, KOL 가격 책정 등 공개 데이터 워크플로를 위한 호스팅 원격 MCP 서버.
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server
 
 ---

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -290,6 +290,7 @@
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
+- UnifAPI — https://github.com/unifapi-agent/unifapi-mcp-server - 托管式远程 MCP 服务，覆盖社交、搜索、抓取、新闻、创作者研究和 KOL 定价等公共数据工作流。
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch/SearXNG — https://github.com/mnhlt/WebSearch-MCP 与 https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors 与 RAG Web Browser — https://github.com/apify/actors-mcp-server 与 https://github.com/apify/mcp-server-rag-web-browser

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -306,6 +306,7 @@
 - Tavily — https://github.com/Tomatio13/mcp-server-tavily
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server
 - PapersWithCode — https://github.com/hbg/mcp-paperswithcode
+- UnifAPI — https://github.com/unifapi-agent/unifapi-mcp-server - 託管式遠端 MCP 服務，涵蓋社群、搜尋、抓取、新聞、創作者研究與 KOL 定價等公共資料工作流。
 - Playwright — https://github.com/executeautomation/mcp-playwright
 - Websearch / SearXNG — https://github.com/mnhlt/WebSearch-MCP 與 https://github.com/ihor-sokoliuk/mcp-searxng
 - Apify Actors 與 RAG Web Browser — https://github.com/apify/actors-mcp-server 與 https://github.com/apify/mcp-server-rag-web-browser


### PR DESCRIPTION
## Summary
- Add UnifAPI to the Search & Web category.
- Keep the English, Chinese, Traditional Chinese, Japanese, and Korean READMEs in sync.

## Verification
- Official MCP Registry entry is active for com.unifapi/mcp.
- Remote endpoint is https://mcp.unifapi.com.