### PR TITLE
Add Hive Intelligence to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Game engines and tooling.
 Payments, market data, and finance tools.
 
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
+- Hive Intelligence (⭐) — https://github.com/hive-intel/hive-sdk (managed crypto intelligence MCP with hosted HTTP, local stdio, SDK, and skills for market data, DeFi, wallets, security, Solana, and prediction markets)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server

--- a/README_ja.md
+++ b/README_ja.md
@@ -407,6 +407,7 @@ Web フェッチ、スクレイピング、検索。
 
 決済、マーケットデータ、ファイナンスツール。
 
+- Hive Intelligence (⭐) — https://github.com/hive-intel/hive-sdk (AI エージェント向けのマネージド暗号資産インテリジェンス MCP。ホスト HTTP、ローカル stdio、SDK、スキルを提供)
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol

--- a/README_ko.md
+++ b/README_ko.md
@@ -320,6 +320,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 
 ## 카테고리: 금융 (💹)
 
+- Hive Intelligence (⭐) — https://github.com/hive-intel/hive-sdk (AI 에이전트를 위한 관리형 암호화폐 인텔리전스 MCP. hosted HTTP, local stdio, SDK, skills 지원)
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 
@@ -390,5 +391,4 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 - 신뢰할 수 없는 커뮤니티 서버는 컨테이너 또는 VM 같은 격리 환경에서 실행하십시오。
 - 프로덕션 환경에서는 공식(⭐) 구현을 우선 사용하십시오。
 - 각 서버의 리포지토리에서 전송 방식(stdio, SSE, HTTP)、인증 및 예제 클라이언트를 확인하십시오。
-
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -395,6 +395,7 @@ Shell、操作系统与任务自动化相关。
 
 支付、市场数据与金融服务。
 
+- Hive Intelligence（⭐） — https://github.com/hive-intel/hive-sdk（面向 AI 代理的托管加密情报 MCP，支持托管 HTTP、本地 stdio、SDK 与技能）
 - Octagon（⭐） — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee（⭐） — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
@@ -646,4 +647,3 @@ Shell、操作系统与任务自动化相关。
 - 在生产环境中优先使用官方厂商维护的服务器（标注为 ⭐）。
 - 查阅每个服务器仓库，了解其支持的传输方式（stdio、SSE、HTTP）、鉴权方式与示例客户端。
 - 该生态系统发展迅速，新的服务器、客户端和框架不断加入。维护者请确保仓库包含清晰的安装与安全说明。
-

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -410,6 +410,7 @@ Shell、作業系統與任務自動化相關工具：
 
 支付、行情資料與金融服務：
 
+- Hive Intelligence（⭐） — https://github.com/hive-intel/hive-sdk（面向 AI 代理的託管加密情報 MCP，支援託管 HTTP、本地 stdio、SDK 與技能）
 - Octagon（⭐） — https://github.com/OctagonAI/octagon-mcp-server
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee（⭐） — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
@@ -662,5 +663,4 @@ AI 與機器學習服務整合：
 - 正式環境建議優先使用官方廠商維護的伺服器（標註為 ⭐）。
 - 檢視各伺服器倉庫以了解支援之傳輸方式（stdio、SSE、HTTP）、認證方式與範例用戶端。
 - 此生態系迅速演進，新伺服器、用戶端與框架經常加入；維護者請確保倉庫附有清楚的安裝與安全說明。
-
 


### PR DESCRIPTION
## Summary
- Add Hive Intelligence to the Finance category as a managed crypto intelligence MCP for AI agents.
- Update the English, Chinese, Traditional Chinese, Japanese, and Korean README variants.

## Verification
- git diff --check
- curl -L -sS -o /dev/null -w '%{http_code}' https://github.com/hive-intel/hive-sdk -> 200
- markdown-link-check focused check for the new Hive link