### PR TITLE
Add @worldcitisim/mcp-esim

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Commerce and marketplace integrations.
 - Mercado Libre — https://mcp.mercadolibre.com/
 - Gunsnation — https://github.com/DynamicDeals/mcp-server-gunsnation
 - ShopSavvy (⭐) — https://github.com/shopsavvy/shopsavvy-mcp-server
+- WorldCitiSim eSIM — https://github.com/easyname889/worldcitisim-frontend/tree/main/apps/mcp-server
 
 ---
 


### PR DESCRIPTION
WorldCitiSim MCP server for travel eSIMs (193 countries + UK SMS verification numbers). Stripe + Bitcoin checkout, QR delivered by email in ~30s. Anonymous, no API key needed.

Live: https://worldcitisim.com/developers
npm: https://www.npmjs.com/package/@worldcitisim/mcp-esim
MCP Registry: com.worldcitisim/mcp-esim