### PR TITLE
Add freellmpool to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- freellmpool — https://github.com/0xzr/freellmpool
 
 ---
 


### PR DESCRIPTION
Adds [freellmpool](https://github.com/0xzr/freellmpool) to **AI Services**.

`freellmpool mcp` is an MCP server that exposes pooled **free** LLM tiers from 16 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, …) as ask/models/quota tools, with automatic failover. Keyless to start (`pip install freellmpool`). Same genre as the existing "OpenAI Compatible Chat" entry.