### PR TITLE
docs(finance): add The Stall — x402 pay-per-call A2A intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- The Stall (domain-agnostic A2A intelligence chassis; US stock price, concentration risk score, market intelligence for AI agents; pay-per-call x402 on Base) — https://the-stall.intuitek.ai
 
 ---
 


### PR DESCRIPTION
Adds The Stall to the Finance section.

The Stall is a live x402 pay-per-call A2A intelligence MCP chassis at https://the-stall.intuitek.ai

Capabilities:
- `us-stock-price` — real-time US equity prices via Yahoo Finance ($0.030/call)
- `concentration-risk-score` — on-chain concentration risk scoring
- `market-intelligence` — on-chain market intelligence
- `ping` — health check

Payments settle in USDC on Base mainnet via x402. No API key required.