### PR TITLE
docs: add twzrd-agent-intel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Payments, market data, and finance tools.
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---
+- TWZRD Agent Intel — https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel (Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust $0.05 + market intel $0.03 in USDC. Hosted MCP at intel.twzrd.xyz/mcp)
 
 ## Category: Research & Data (🧬)
 


### PR DESCRIPTION
Add **TWZRD Agent Intel** — Solana on-chain agent trust scoring via x402 micropayments.

- Free: preflight readiness check, score lookup, top-agents leaderboard, receipt verification
- Paid: trust score ($0.05/call), market intel ($0.03/call) in USDC on Solana mainnet
- Hosted MCP: `https://intel.twzrd.xyz/mcp` (streamable-http, no API key needed)
- PyPI: `pip install twzrd-agent-intel`
- Listed on: official MCP Registry, Smithery (quality 98), mcp.so

GitHub: https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel
