### PR TITLE
feat: add TWZRD Agent Intel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- TWZRD Agent Intel (Solana-native x402 MCP for agent trust scoring — 4 free preflight tools + 4 paid signed trust receipts, <1s settlement on Solana) — https://intel.twzrd.xyz
 
 ---
 


### PR DESCRIPTION
## What

Adds **TWZRD Agent Intel** to the Finance (💹) category.

- **URL**: https://intel.twzrd.xyz
- **MCP endpoint**: https://intel.twzrd.xyz/mcp
- **MCP Registry**: `xyz.twzrd.intel/twzrd-agent-intel`

## Why it fits

TWZRD Agent Intel is a Solana-native MCP server that provides agent trust scoring via x402 micropayments — the first such tool in the ecosystem:

- **4 free tools**: preflight scoring for any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior)
- **4 paid tools**: HTTP 402 flow returning signed `twzrd.receipt.v5` trust tokens, <1s USDC settlement on Solana
- Sits naturally alongside the existing `x402engine-mcp` and `awesome-x402` entries in the Finance section

The project is live and production-ready, listed on the official MCP Registry.