### PR TITLE
feat(ja): add TWZRD Agent Intel to Finance section (Japanese README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- TWZRD Agent Intel (Solana-native x402 MCP for agent trust scoring — 4 free preflight tools + 4 paid signed trust receipts, <1s settlement on Solana) — https://intel.twzrd.xyz
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -415,6 +415,7 @@ Web フェッチ、スクレイピング、検索。
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
+- TWZRD Agent Intel — https://intel.twzrd.xyz/mcp (Solana x402トラストスコアリング、無料の事前確認とUSDP支払い済み署名付き証明書)
 
 ---
 


### PR DESCRIPTION
## What

Adds **TWZRD Agent Intel** to the カテゴリ：ファイナンス（💹）section of the Japanese README.

## About TWZRD Agent Intel

TWZRD Agent Intel is a Solana-native MCP server that provides AI agent trust scoring via x402 micropayments:

- **Free tools**: On-chain preflight checks, trust score lookups, leaderboard queries, receipt verification
- **Paid tools**: Signed `twzrd.receipt.v5` trust tokens via HTTP 402, USDC micropayment (<1s Solana settlement)
- **MCP endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- **Website**: https://intel.twzrd.xyz
- **Repo**: https://intel.twzrd.xyz