### PR TITLE
feat(ko): add TWZRD Agent Intel to Finance section (Korean README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- TWZRD Agent Intel (Solana-native x402 MCP for agent trust scoring — 4 free preflight tools + 4 paid signed trust receipts, <1s settlement on Solana) — https://intel.twzrd.xyz
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -322,6 +322,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
+- TWZRD Agent Intel — https://intel.twzrd.xyz/mcp (Solana x402 트러스트 스코어링: 무료 사전 확인 및 USDC 유료 서명 영수증)
 
 ---
 


### PR DESCRIPTION
## What

Adds **TWZRD Agent Intel** to the 카테고리: 금융 (💹) section of the Korean README.

## About TWZRD Agent Intel

TWZRD Agent Intel is a Solana-native MCP server that provides AI agent trust scoring via x402 micropayments:

- **Free tools**: On-chain preflight checks, trust score lookups, leaderboard queries, receipt verification
- **Paid tools**: Signed `twzrd.receipt.v5` trust tokens via HTTP 402, USDC micropayment (<1s Solana settlement)
- **MCP endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- **Website**: https://intel.twzrd.xyz
- **Repo**: https://intel.twzrd.xyz