### PR TITLE
feat(zh-tw): add TWZRD Agent Intel — Solana x402 trust scoring MCP server (Traditional Chinese README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- TWZRD Agent Intel (Solana-native x402 MCP for agent trust scoring — 4 free preflight tools + 4 paid signed trust receipts, <1s settlement on Solana) — https://intel.twzrd.xyz
 
 ---
 

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -418,6 +418,7 @@ Shell、作業系統與任務自動化相關工具：
 - PayPal（⭐） — https://github.com/paypal/agent-toolkit
 - Stripe（⭐） — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI（⭐） — https://github.com/longportapp/openapi/tree/main/mcp
+- TWZRD Agent Intel — https://intel.twzrd.xyz/mcp (基於Solana區塊鏈的AI智能體信任評分MCP伺服器，透過x402微支付實現。免費預檢工具 + 付費信任證明($0.05 USDC))
 
 ---
 


### PR DESCRIPTION
添加 TWZRD Agent Intel — 基於Solana的AI智能體信任評分MCP伺服器

## What this adds

**TWZRD Agent Intel** is an MCP server for AI agent trust scoring on Solana, using x402 micropayments for paid tools.

- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable HTTP, zero install)
- **Website**: https://intel.twzrd.xyz
- **PyPI**: https://pypi.org/project/twzrd-agent-intel/

### Tools
| Tool | Cost | Description |
|------|------|-------------|
| `resolve_agent` | Free | Resolve a Solana wallet/agent address to identity metadata |
| `score_agent` | Free | Get trust score and activity metrics for an agent |
| `preflight_check` | Free | Check if an agent meets trust thresholds before transacting |
| `verify_trust_receipt` | Free | Verify a previously issued trust receipt |
| `get_trust_receipt` | $0.05 USDC (x402) | Get a signed, on-chain-verified trust certificate |

### Usage
```json
{
  "mcpServers": {
    "twzrd-agent-intel": {
      "url": "https://intel.twzrd.xyz/mcp",
      "transport": "streamable-http"
    }
  }
}
```

### Addition location
Under `## 分類：金融（💹）` section, after LongPort OpenAPI entry.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)