### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Payments, market data, and finance tools.
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---
-- TWZRD Agent Intel — https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel (Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust $0.05 + market intel $0.03 in USDC. Hosted MCP at intel.twzrd.xyz/mcp)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — Solana-native MCP server for AI agent trust scoring via x402 micropayments. Free preflight checks + paid signed trust receipts in USDC. Hosted MCP at https://intel.twzrd.xyz/mcp
 
 ## Category: Research & Data (🧬)
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Payments, market data, and finance tools.
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---
+- TWZRD Agent Intel — https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel (Solana on-chain agent trust scoring via x402 micropayments. Free preflight + paid trust $0.05 + market intel $0.03 in USDC. Hosted MCP at intel.twzrd.xyz/mcp)
 
 ## Category: Research & Data (🧬)
 


### PR DESCRIPTION
Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — Solana-native x402 MCP server for agent trust scoring.

4 free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. 1 paid: `get_trust_receipt` via x402 (<$0.01 USDC). Zero-install Streamable HTTP.

Install: `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp`