### PR TITLE
feat: add TWZRD Agent Intel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
+- TWZRD Agent Intel — https://intel.twzrd.xyz (trust scoring for Web3 AI agents before x402 payments; free tools: score_agent, preflight_check; MCP at https://intel.twzrd.xyz/mcp; pip install twzrd-agent-intel)
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Finance section.

TWZRD provides trust scoring for Web3 AI agents before x402 payments — a practical tool for autonomous agents making USDC payments on Solana.

**Tools:**
- score_agent(wallet) — 0–100 trust score + on-chain signals (free)
- preflight_check(wallet) — go/no-go before payment (free)
- get_trust_receipt(wallet) — signed on-chain receipt (x402 paid)

**MCP server:** https://intel.twzrd.xyz/mcp (streamable-http)
**Install:** pip install twzrd-agent-intel