### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- ProposalCraft — https://github.com/jabbawocky/proposalcraft — MCP server for freelancers and consultants. Drafts client proposals in your voice from your past winning work. 8 tools, freemium, MIT, no API key.
 
 ---
 


### PR DESCRIPTION
ProposalCraft is an open-source MCP server for Claude Desktop that drafts client proposals in the user's voice. Users save 2–3 past winning proposals; the server loads them as style examples when generating new ones from a client brief. Zero API key required (works with the user's existing Claude Desktop subscription), MIT licensed, installs via `npx -y github:jabbawocky/proposalcraft`. Added to the Marketing section.