### PR TITLE
Add agent-qa MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Developer-focused MCP servers and tools.
 - Postman — https://github.com/delano/postman-mcp-server
 - QA Sphere (⭐) — https://github.com/Hypersequent/qasphere-mcp
 - flutter-skill — https://github.com/ai-dashboad/flutter-skill — AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
+- agent-qa — https://github.com/vostride/agent-qa — Local MCP server for authoring, running, validating, and triaging natural-language web and mobile QA tests with execution memory.
 - marimo (⭐) — https://github.com/marimo-team/codemirror-mcp
 - Figma — https://github.com/GLips/Figma-Context-MCP
 - Comet Opik (⭐) — https://github.com/comet-ml/opik-mcp


### PR DESCRIPTION
## Summary

Adds `agent-qa` to the Development Tools category.

## Why

`agent-qa` provides a local MCP server for authoring, running, validating, and triaging natural-language web and mobile QA tests. It fits near the existing QA Sphere and E2E testing MCP entries.
