### PR TITLE
Add official monday.com MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Official integrations are maintained by companies building production-ready MCP 
 - Aiven — https://github.com/Aiven-Open/mcp-aiven
 - AlibabaCloud DevOps MCP — https://github.com/aliyun/alibabacloud-devops-mcp-server
 - Apify Actors — https://github.com/apify/actors-mcp-server
+- monday.com — https://github.com/mondaycom/mcp (⭐)
 - Box — https://github.com/box-community/mcp-server-box (⭐)
 - Cloudflare — https://github.com/cloudflare/mcp-server-cloudflare (⭐)
 - GitHub — https://github.com/github/github-mcp-server (official)


### PR DESCRIPTION
Adds the official monday.com MCP server to the Official Servers section.

- Repo: https://github.com/mondaycom/mcp
- Official vendor MCP, maintained by monday.com
- Hosted endpoint: https://mcp.monday.com/mcp (OAuth 2.1)
- Local: npm `@mondaydotcomorg/monday-api-mcp` (run via npx, API-token auth)

Lets agents manage boards, items, columns, groups, docs, and workspace data. Marked official with ⭐.

Made with [Cursor](https://cursor.com)