### PR TITLE
Add The Stall to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- The Stall (173+ pay-per-call x402 capabilities for AI agents — stocks, options chains, DeFi yields, blockchain analytics, and wallet intelligence; USDC on Base mainnet, no API keys required) — https://the-stall.intuitek.ai
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
-- The Stall (173+ pay-per-call x402 capabilities for AI agents — stocks, options chains, DeFi yields, blockchain analytics, and wallet intelligence; USDC on Base mainnet, no API keys required) — https://the-stall.intuitek.ai
+- The Stall (178+ pay-per-call x402 capabilities for AI agents — stocks, options chains, DeFi yields, blockchain analytics, and wallet intelligence; USDC on Base mainnet, no API keys required) — https://the-stall.intuitek.ai
 
 ---
 


### PR DESCRIPTION
Add [The Stall](https://the-stall.intuitek.ai) — a pay-per-call x402 capability chassis for AI agents with **201 data capabilities** including stock prices, options chains, DeFi yields, blockchain analytics, Korean market movers (Upbit), wallet intelligence, and more. Payments via USDC on Base mainnet. No API key needed — agents pay per call at the moment of need.

- 🌐 **Endpoint**: https://the-stall.intuitek.ai/mcp
- 💳 **Payment**: x402 (USDC on Base)
- 📦 **201 capabilities**: finance, crypto, DeFi, macro, social, web intelligence
- ✅ **Production ready**: v4.55.0

The Stall is listed on the MCP Registry, Smithery, and Glama, and is one of the most comprehensive x402 pay-per-call MCP servers available.