### PR TITLE
feat: The Stall — 210 pay-per-call AI capabilities via x402 MCP (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- The Stall (thebrierfox/the-stall) — 181 pay-per-call MCP tools via x402 USDC micropayments on Base: global markets, US equities, DeFi/crypto, sanctions screening (OFAC 19K+ entries), global news intelligence (200+ languages), and crypto infrastructure. No API keys or accounts required. MCP: https://the-stall.intuitek.ai/mcp
 
 ---
 


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, gamma exposure, macro, congressional trades, weather, aviation weather, vision analysis, Twitter/X intelligence, cron tools, domain intel, and 195+ more.

**New in v4.64.0–v4.64.0:**
- `twitter-intel` — real-time X/Twitter data via x402-to-x402 (twit.sh), no API key needed ($0.008/call)
- `market-gex` — dealer gamma exposure (GEX) for any US equity using free CBOE data; returns gamma flip level, vol regime, key pin strikes ($0.02/call)
- `vision-analyze` — image analysis via GPT-4o Vision; accepts URL or base64
- `energy-brief` v2 — upgraded to Yahoo Finance real-time (9 signals: WTI/Brent/NG futures + XLE/OIH/XOM/CVX/MPC/BKR)

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: 5814690 | version: v4.64.0