### PR TITLE
Add podium-mcp - Unified mobile E2E testing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Developer-focused MCP servers and tools.
 - Postman — https://github.com/delano/postman-mcp-server
 - QA Sphere (⭐) — https://github.com/Hypersequent/qasphere-mcp
 - flutter-skill — https://github.com/ai-dashboad/flutter-skill — AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
+- podium-mcp — https://github.com/hoainho/podium-mcp — Unified mobile E2E testing via MCP — iOS simulator control, native UI introspection, Maestro flows, React Native debugging, and WebView DOM inspection.
 - marimo (⭐) — https://github.com/marimo-team/codemirror-mcp
 - Figma — https://github.com/GLips/Figma-Context-MCP
 - Comet Opik (⭐) — https://github.com/comet-ml/opik-mcp


### PR DESCRIPTION
Adds [podium-mcp](https://github.com/hoainho/podium-mcp) to the Development Tools section — a unified MCP server for mobile E2E testing providing iOS simulator control, native UI automation, Maestro flows, React Native debugging, and WebView DOM inspection.