### PR TITLE
feat: add The Stall — 209 pay-per-call data capabilities via x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- The Stall (thebrierfox/the-stall) — 181 pay-per-call MCP tools via x402 USDC micropayments on Base: global markets, US equities, DeFi/crypto, sanctions screening (OFAC 19K+ entries), global news intelligence (200+ languages), and crypto infrastructure. No API keys or accounts required. MCP: https://the-stall.intuitek.ai/mcp
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- The Stall (209 pay-per-call data capabilities via x402 MCP: stocks, crypto, DeFi, Polymarket, macro intelligence — USDC on Base, no API keys) — https://github.com/thebrierfox/the-stall
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 - The Stall (thebrierfox/the-stall) — 181 pay-per-call MCP tools via x402 USDC micropayments on Base: global markets, US equities, DeFi/crypto, sanctions screening (OFAC 19K+ entries), global news intelligence (200+ languages), and crypto infrastructure. No API keys or accounts required. MCP: https://the-stall.intuitek.ai/mcp
 


### PR DESCRIPTION
## Summary

Adds [The Stall](https://github.com/thebrierfox/the-stall) by [IntuiTek¹](https://intuitek.ai) to the **Finance** category.

**The Stall** is a live x402-native MCP server with 209 pay-per-call data capabilities:
- Stocks, ETFs, options
- Crypto and on-chain analytics
- DeFi intelligence
- Polymarket prediction market data
- Global macro and geopolitical signals
- USDC micropayments on Base via x402 — no API keys needed

**Links:**
- GitHub: https://github.com/thebrierfox/the-stall
- Live endpoint: https://the-stall.intuitek.ai
- MCP endpoint: https://the-stall.intuitek.ai/mcp
- Glama: https://glama.ai/mcp/servers/thebrierfox/the-stall