### PR TITLE
Add Superhighway to Search & Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Web fetching, scraping, and search.
 - Fetch — https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
 - Kagi Search — https://github.com/ac3xx/mcp-servers-kagi
 - Exa Search (⭐) — https://github.com/exa-labs/exa-mcp-server
+- Superhighway — https://github.com/patwalls/superhighway-mcp — five tools (search, news, images, scrape, research); agents pay per call via x402 USDC or free API key
 - NYTimes — https://github.com/angheljf/nyt
 - Google News — https://github.com/ChanMeng666/server-google-news
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server


### PR DESCRIPTION
## What

Adds **Superhighway** to the 🔍 Search & Web section alongside Exa Search, Tavily, Kagi, and Brave Search.

- **[superhighway-mcp](https://github.com/patwalls/superhighway-mcp)** — five web search tools (search, news, images, scrape, research); agents pay per call via x402 USDC or free API key
- Install: `npx -y superhighway-mcp` (TypeScript, on npm)
- Homepage: https://superhighway.walls.sh

## Why it fits

Superhighway is a web search API specifically designed for AI agents — agents can pay for individual searches autonomously via the x402 protocol (USDC on Base), or use a free API key. It's the search-API peer of Exa, Tavily, and Brave in this section.