### PR TITLE
Add FiatDock — non-custodial MCP marketplace for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- FiatDock (non-custodial USDC ↔ bank on/off-ramp for AI agents: free quotes, x402-paid sessions, order tracking; remote MCP + npx fiatdock-mcp) — https://github.com/fiatdock/fiatdock
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Payments, market data, and finance tools.
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
-- FiatDock (non-custodial USDC ↔ bank on/off-ramp for AI agents: free quotes, x402-paid sessions, order tracking; remote MCP + npx fiatdock-mcp) — https://github.com/fiatdock/fiatdock
+- FiatDock (non-custodial marketplace where AI agents discover and pay for MCP services per call in USDC via x402 on Base — 3 tools: search_services/get_service/call_service; payments settle buyer→seller, 1% on-chain split (0% a seller's first 30 days), never custodial; sellers list free; also a USDC↔bank on/off-ramp; remote MCP + npx fiatdock-mcp) — https://github.com/fiatdock/fiatdock
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---


### PR DESCRIPTION
This updates the FiatDock entry to lead with what it is today: a **non-custodial marketplace where AI agents discover and pay for MCP services per call** via x402 on Base.

- 3 MCP tools — `search_services`, `get_service`, `call_service`.
- Each paid call settles **directly buyer-wallet → seller-wallet**; the 1% platform fee is an **on-chain split** (0% for a seller's first 30 days), so FiatDock never holds funds.
- Sellers list **free** and keep 99%; Verified sellers pass a KYC + security scan.
- Also exposes a non-custodial **USDC↔bank on/off-ramp**.

Site: https://fiatdock.com · what it is: https://fiatdock.com/mcp-marketplace.html · `npx fiatdock-mcp` · remote MCP `https://fiatdock.com/mcp`
