### PR TITLE
Add ChatCrystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- ChatCrystal — https://github.com/ZengLiangYi/ChatCrystal (Local-first AI PKM memory server for coding conversations. Imports Claude Code, Cursor, Codex CLI, Trae, and GitHub Copilot chats into notes, semantic search, tag graphs, Markdown exports, and MCP memory tools. Install via `npx -y chatcrystal mcp`; official MCP Registry: `io.github.ZengLiangYi/chatcrystal`.)
 
 ---
 


### PR DESCRIPTION
Adds ChatCrystal to the Note Taking category. ChatCrystal is a local-first AI PKM memory server for coding conversations, available through the official MCP Registry as io.github.ZengLiangYi/chatcrystal and installable via 
px -y chatcrystal mcp. Repo: https://github.com/ZengLiangYi/ChatCrystal