### PR TITLE
Add VideoOverlayKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ Books, libraries, and creative tools.
 
 - MCP Open Library — https://github.com/8enSmith/mcp-open-library
 - Pollinations — https://github.com/pollinations/model-context-protocol
+- VideoOverlayKit — https://github.com/alichherawalla/video-overlay-kit
 
 ---
 


### PR DESCRIPTION
Adds [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) — animated b-roll overlay renderer for short-form video. MCP-driven (paste a script, AI writes the scene spec, renders mp4). Free, MIT, runs locally. Live preview: https://alichherawalla.github.io/video-overlay-kit/