### PR TITLE
Add AccInt MCP memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- AccInt — https://github.com/maxbaluev/accreted-intelligence (Local-first MCP work memory for coding agents with scored retrieval, commitment tracking, and outcome-based credit across sessions.)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds AccInt to the Note Taking category alongside other personal knowledge and agent-memory MCP servers.

AccInt is a local-first MCP work memory for coding agents: scored retrieval, commitment tracking, and outcome-based credit help Claude Code, Codex, Cursor, and OpenCode reuse lessons across sessions. The public repository contains installer/docs/MCP and plugin integration glue plus release artifacts; the core engine binary is currently private, so the entry is intentionally limited to the public MCP surface and behavior.

I only updated `README.md` because recent accepted MCP additions in this repository, including Knowledge/Memory-style entries, used README-only changes.

## Validation

- `git diff --check`
- `https://github.com/maxbaluev/accreted-intelligence` returns HTTP 200
- `https://accint.xyz/` returns HTTP 200