### PR TITLE
feat: add Grafema — semantic code graph MCP server to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- Grafema — https://github.com/Disentinel/grafema — Semantic code graph MCP server for AI coding agents. Indexes codebases into a typed graph (functions/types/modules; CALLS/IMPORTS/DATAFLOW/EFFECTS edges) with 40+ tools for call-chain tracing, data-flow analysis, and semantic code search.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
## What

Adds [Grafema](https://github.com/Disentinel/grafema) to the **Development Tools (💻)** category.

## About Grafema

Grafema is a semantic code graph MCP server for AI coding agents. It indexes a codebase into a typed, persistent graph:

- **Nodes:** functions, types, modules, variables, files
- **Edges:** CALLS, IMPORTS, DATAFLOW, EFFECTS, DERIVES, EXPORTS — all typed
- **40+ MCP tools:** `trace_calls`, `trace_dataflow`, `find_nodes`, `semantic_search`, `check_invariant`, and more
- **Transport:** stdio
- **Install:** `npm install -g grafema`
- **License:** FSL-1.1-Apache-2.0
- **Platform:** macOS (arm64/x64), Linux (arm64/x64)

Instead of reading files line by line, agents query the graph directly — tracing call chains, finding all callers of a function, checking data-flow across modules, or detecting invariant violations.

## Checklist

- [x] Entry follows the existing format
- [x] Link goes to the official GitHub repo
- [x] Description is accurate and concise
- [x] Placed in the correct category (Development Tools)