### PR TITLE
Add HumanHours MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Integration with chat and messaging platforms.
 
 Access observability and monitoring systems.
 
+- HumanHours — https://github.com/triadgit/humanhours-mcp - remote MCP for agent ROI (hours and money saved) and company enrichment into roles and per-hour wages; OAuth 2.1, no install (https://mcp.humanhours.dev/mcp)
 - Metoro — https://github.com/metoro-io/metoro-mcp-server
 - Raygun — https://github.com/MindscapeHQ/mcp-server-raygun
 - Sentry — https://github.com/modelcontextprotocol/servers/tree/main/src/sentry


### PR DESCRIPTION
Adds HumanHours under Monitoring.

HumanHours is a remote MCP server for tracking AI-agent ROI (hours and money saved) and enriching companies into roles + per-hour wages.

- Repo: https://github.com/triadgit/humanhours-mcp
- Endpoint: https://mcp.humanhours.dev/mcp (streamable HTTP, OAuth 2.1, no install, no API keys)
- Registry id: dev.humanhours/humanhours
- Docs: https://humanhours.dev/docs/mcp