### PR TITLE
Add NotFair to Marketing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- NotFair — https://github.com/nowork-studio/NotFair — Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, connecting to live data via the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Skill areas: [seo/](https://github.com/nowork-studio/NotFair/tree/main/seo), [google-ads/](https://github.com/nowork-studio/NotFair/tree/main/google-ads), and [meta-ads/](https://github.com/nowork-studio/NotFair/tree/main/meta-ads).
 
 ---
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a really useful map of the MCP ecosystem.

I'd like to suggest adding NotFair to the Marketing category, right alongside the existing Facebook Ads and Google Ads entries. NotFair is an open-source (MIT, ~2.9k stars) set of Claude Code skills for SEO, GEO, Google Ads, and Meta Ads work. It pulls live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so it fits naturally with the marketing/analytics tools already listed here.

I kept the entry to one line in the same style as its neighbors and linked the seo/, google-ads/, and meta-ads/ skill folders. Happy to reword, shorten, or move it to a different spot if you'd prefer — just let me know.