### PR TITLE
Add ax monitoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Integration with chat and messaging platforms.
 
 Access observability and monitoring systems.
 
+- ax — https://github.com/Necmttn/ax — Local MCP over coding-agent telemetry, sessions, tool calls, skills, costs, and OTLP events.
 - Metoro — https://github.com/metoro-io/metoro-mcp-server
 - Raygun — https://github.com/MindscapeHQ/mcp-server-raygun
 - Sentry — https://github.com/modelcontextprotocol/servers/tree/main/src/sentry


### PR DESCRIPTION
Adds ax to the Monitoring category. ax exposes a local MCP interface over coding-agent telemetry: sessions, tool calls, skills, costs, and OTLP events.

Validation:
- `git diff --check`
- Added GitHub link returns HTTP 200

---

_Generated with [ax](https://github.com/Necmttn/ax)._