### PR TITLE
Add AgentRecall — correction-first persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Papers, datasets, and domain data.
 
 AI model & ML service integrations.
 
+- AgentRecall — https://github.com/Goldentrii/AgentRecall-MCP — Correction-first persistent memory for AI agents. Logs every correction as a CorrectionRecord with precision KPI (heeded/retrieved), compounds via 5 memory layers. FSRS-lite decay, Hopfield retrieval. Local markdown, no cloud. `npx agent-recall-mcp`
 - Agentset AI — https://github.com/agentset-ai/mcp-server
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai


### PR DESCRIPTION
## Adding AgentRecall to AI Services

**AgentRecall** ([GitHub](https://github.com/Goldentrii/AgentRecall-MCP) · [npm: agent-recall-mcp](https://www.npmjs.com/package/agent-recall-mcp)) is a correction-first persistent memory MCP server for AI agents.

### What makes it distinct

Unlike general-purpose memory tools that store facts, AgentRecall's core primitive is the **CorrectionRecord**: every time a user corrects an agent, the correction is logged with severity, evidence, and a precision KPI (`heeded_count / retrieved_count`). After N confirmations across sessions it auto-promotes to a cross-project insight. This makes memory quality measurable.

### Key specs

- **5 memory layers** — episodic, semantic, procedural, narrative, correction
- **Published math** — FSRS-lite decay, Modern Hopfield retrieval (Ramsauer 2020), RRF fusion
- **Local-first** — `~/.agent-recall/`, no cloud, no API keys
- **5 MCP tools** — `session_start`, `remember`, `recall`, `check`, `session_end`
- **MIT license**

```bash
npx agent-recall-mcp
```