### PR TITLE
Add TwitterAPI.io MCP Server (Social Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Social platforms integration.
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp
 - X/Twitter — https://github.com/mbelinky/x-mcp-server
 - Social Neuron (52 MCP tools for AI-powered social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning) — https://github.com/socialneuron/mcp-server [npm: @socialneuron/mcp-server]
+- TwitterAPI.io ([twitterapi.io](https://twitterapi.io)) — Twitter / X data API for AI agents; hosted MCP at mcp.twitterapi.io/mcp, 12 read-only tools: tweet search with full operators, profiles, followers, conversation threads, real-time WebSocket streaming, trending topics — https://github.com/kaitoInfra/twitterapi-io-mcp-server [npm: @kaitoinfra/twitterapi-io-mcp-server]
 
 ---
 


### PR DESCRIPTION
Adds **TwitterAPI.io MCP Server** to the Social Media category.

- **Repo**: https://github.com/kaitoInfra/twitterapi-io-mcp-server  (MIT)
- **npm**: `@kaitoinfra/twitterapi-io-mcp-server`
- **Hosted endpoint**: `https://mcp.twitterapi.io/mcp` (streamable-http — works in Claude Desktop / Cursor / any MCP client without local install)
- **MCP Registry**: `io.github.kaitoInfra/twitterapi-io-mcp-server` (active since 2026-05-23)

### Why it fits

This is a hosted **Twitter / X data API** packaged as an MCP server — different value prop from the existing `X/Twitter` entry (which is a Twitter-account write/post tool). 12 read-only tools for tweet search (full operator syntax), user profile / followers, conversation thread expansion, real-time WebSocket streaming, and trending topics. Free signup tier, pay-per-call thereafter — no Twitter Developer Platform application needed.

Matches the format of the existing entries in the Social Media section. Happy to revise wording if a different convention is preferred.
