### PR TITLE
Add Vestige MCP memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- Vestige — https://github.com/samvallad33/vestige (Local-first cognitive memory MCP server for coding agents with SQLite storage, FSRS-style retention, hybrid retrieval, provenance/correction tools, and dashboard inspection.)
 
 ---
 


### PR DESCRIPTION
Adds Vestige to the Note Taking / memory-adjacent section.

Vestige is a local-first cognitive memory MCP server for coding agents, with SQLite storage, FSRS-style retention, hybrid retrieval, provenance/correction tools, and dashboard inspection.

Checks: git diff --check
