### PR TITLE
Add text2sql-mcp under Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Database access with schema inspection and query capabilities.
 - Airtable — https://github.com/domdomegg/airtable-mcp-server
 - Snowflake — https://github.com/isaacwasserman/mcp-snowflake-server
 - DBUtils — https://github.com/donghao1393/mcp-dbutils
-- text2sql — https://github.com/cpenniman12/text2sql-mcp (natural-language SQL agent; explores the schema, writes SQL, and self-corrects on errors — no RAG or schema descriptions required. SQLite, Postgres, MySQL, Snowflake, and BigQuery via install extras.)
+- text2sql — https://github.com/cpenniman12/text2sql-mcp (Frontier models can now make hundreds of iterative tool calls per prompt — so instead of pre-computing which schema elements are relevant, you can hand the LLM one tool (`execute_sql`) and let it explore the schema, write queries, and self-correct. No RAG, semantic layer, or schema descriptions required — just a connection string and a frontier model. SQLite, Postgres, MySQL, Snowflake, and BigQuery via install extras.)
 - TiDB — https://github.com/c4pt0r/mcp-server-tidb
 - NocoDB — https://github.com/edwinbernadus/nocodb-mcp-server
 - Couchbase (⭐) — https://github.com/Couchbase-Ecosystem/mcp-server-couchbase

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Database access with schema inspection and query capabilities.
 - Airtable — https://github.com/domdomegg/airtable-mcp-server
 - Snowflake — https://github.com/isaacwasserman/mcp-snowflake-server
 - DBUtils — https://github.com/donghao1393/mcp-dbutils
+- text2sql — https://github.com/cpenniman12/text2sql-mcp (natural-language SQL agent; explores the schema, writes SQL, and self-corrects on errors — no RAG or schema descriptions required. SQLite, Postgres, MySQL, Snowflake, and BigQuery via install extras.)
 - TiDB — https://github.com/c4pt0r/mcp-server-tidb
 - NocoDB — https://github.com/edwinbernadus/nocodb-mcp-server
 - Couchbase (⭐) — https://github.com/Couchbase-Ecosystem/mcp-server-couchbase


### PR DESCRIPTION
Adds `cpenniman12/text2sql-mcp` to the **Databases** section.

**What it is:** An MCP server that lets any MCP-compatible client (Claude Desktop, Cursor, Goose, etc.) ask a SQL database questions in natural language. The underlying agent explores the schema, writes SQL, executes it against the real database, and self-corrects on errors — no RAG layer, no pre-written schema descriptions, no embeddings.

**Supports:** SQLite (out of the box), Postgres, MySQL, Snowflake, BigQuery via install extras. Works with Anthropic or OpenAI models.

**Install:** `uvx text2sql-mcp` — published on PyPI.

Repo: https://github.com/cpenniman12/text2sql-mcp
