### PR TITLE
Add DomScan to Search & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Web fetching, scraping, and search.
 - Puppeteer — https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer
 - Brave Search — https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search
 - Bright Data — https://github.com/luminati-io/brightdata-mcp
+- DomScan — https://domscan.net
 - Dumpling AI — https://github.com/Dumpling-AI/mcp-server-dumplingai
 - Fetch — https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
 - Kagi Search — https://github.com/ac3xx/mcp-servers-kagi


### PR DESCRIPTION
Adds **DomScan** (https://domscan.net), a domain intelligence service for DNS, WHOIS/RDAP, SSL/TLS, subdomain discovery, valuation and typosquatting (API and MCP server). Added to the most relevant section in the existing format.