### PR TITLE
Add BankBridge — read-only bank access for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- BankBridge (read-only access to your real bank accounts, transactions, and investment holdings — 12 tools, live-fetched, works with Claude, ChatGPT, Cursor, Gemini, Codex, and 25+ MCP hosts) — https://github.com/bankbridge-money/bankbridge-plugin
 
 ---
 


### PR DESCRIPTION
Adds BankBridge to the Finance category.

[BankBridge](https://bankbridge.money) is a hosted MCP server that gives AI agents read-only access to real bank accounts, transactions, and investment holdings. 12 tools, live-fetched every call. Works with Claude, ChatGPT, Cursor, Gemini, Codex, and 25+ other MCP hosts. \$5/mo per connected bank.

Press kit: https://bankbridge.money/press