### PR TITLE
Add arabicfmt to Language & Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Single MCP endpoints that expose many integrations.
 Translation and language services.
 
 - Lara (⭐) — https://github.com/translated/lara-mcp
+- arabicfmt — https://github.com/cc1a2b/arabicfmt
 
 ---
 


### PR DESCRIPTION
Adds arabicfmt — MCP server (npm: arabicfmt-mcp) for Arabic formatting: currency for all 22 Arab League countries incl. the new Saudi riyal sign U+20C1, Umm al-Qura Hijri dates, number-to-words (تفقيط), RTL/bidi fixes, transliteration and validation. MIT licensed; listed in the official MCP Registry.