### PR TITLE
Add Quota Dashboard MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Access observability and monitoring systems.
 - sslmon — https://github.com/firesh/sslmon-mcp
 - Signoz — https://github.com/DrDroidLab/signoz-mcp-server
 - VictoriaMetrics — https://github.com/VictoriaMetrics-Community/mcp-victoriametrics
+- Quota Dashboard MCP — https://github.com/ryan-knowone/quota-dashboard-mcp — Local MCP server for real-time AI subscription quota across Claude Code Max, Kimi, and Z.ai. Tokens stay on your machine; install with `npx -y ryan-knowone/quota-dashboard-mcp`.
 
 ---
 


### PR DESCRIPTION
Adds [ryan-knowone/quota-dashboard-mcp](https://github.com/ryan-knowone/quota-dashboard-mcp) to the Monitoring category.

A local, privacy-first MCP server that exposes real-time AI subscription quota for Claude Code Max, Kimi, and Z.ai. Tokens stay on the user's machine and are never persisted or forwarded anywhere except the provider APIs.

Install: `npx -y ryan-knowone/quota-dashboard-mcp`

Co-Authored-By: Claude <noreply@anthropic.com>