### PR TITLE
Add rtblint to Marketing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- rtblint — https://github.com/aleksUIX/rtblint
 
 ---
 


### PR DESCRIPTION
Adds rtblint (https://github.com/aleksUIX/rtblint) to the Marketing category, next to the Facebook Ads and Google Ads MCP servers since it's also an ad-tech MCP server, just on the validation side rather than the campaign-management side.

rtblint's MCP server exposes OpenRTB bid request validation (against the IAB Tech Lab spec, versions 2.0 through 3.0) to AI agents: malformed JSON, missing fields, unknown/deprecated fields, type mismatches. There's also a Rust CLI and a free WASM browser tester in the same repo.

I didn't find a CONTRIBUTING.md in this repo, so I matched the existing entry format in this section (name, em dash, link, no separate description). Apache 2.0, actively developed (about 2 months old).

Disclosure: I maintain rtblint, so this is a self-submission rather than a third-party recommendation.