### PR TITLE
Add AgentServices — x402 Finance & Data APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
-- AgentServices — Paid data APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at api.aiservices.to/mcp. [GitHub](https://github.com/vbkotecha/aiservices-api)
+- AgentServices — Paid data APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at agentservices.to/mcp. [GitHub](https://github.com/vbkotecha/aiservices-api)
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Game engines and tooling.
 
 Payments, market data, and finance tools.
 
+- AgentServices — Paid data APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at api.aiservices.to/mcp. [GitHub](https://github.com/vbkotecha/aiservices-api)
 - Omnis Venture Intelligence MCP — https://github.com/HCS412/ventureautomated (remote venture intelligence for autonomous agents: startup discovery, company scoring, monitoring, and enterprise workspace automation) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis)
 - AgentFund — https://github.com/RioBot-Grind/agentfund-mcp
 - Octagon (⭐) — https://github.com/OctagonAI/octagon-mcp-server


### PR DESCRIPTION
## AgentServices

Paid data APIs for AI agents with x402 on Base. 29 endpoints: crypto prices, DeFi yields, technical indicators, marketing intelligence, dispute resolution.

- Live: https://agentservices.to
- MCP: https://agentservices.to/mcp
- Repo: https://github.com/vbkotecha/aiservices-api

Added to Finance category.