### PR TITLE
Add Heym

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Automation platforms and workflow tools.
 - Taskade (⭐) — https://github.com/taskade/mcp
 - Zapier — https://zapier.com/mcp
 - Pipedream — https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol
+- Heym - https://github.com/heymrun/heym - Source-available, self-hosted AI workflow automation platform with a visual canvas for agent, RAG, and tool-using workflows. Supports MCP for exposing workflows as tools and connecting agent nodes to external MCP servers.
 - Tool aggregators like Rube, Rube/Composio and MCPJungle are listed in Aggregators.
 
 ---


### PR DESCRIPTION
## Summary
Adds Heym to the Workflow Automation category.

Heym is a source-available, self-hosted AI workflow automation platform with a visual canvas for agent, RAG, and tool-using workflows. It supports MCP for exposing workflows as tools and connecting agent nodes to external MCP servers.

## Validation
- Confirmed Heym was not already listed in this repository.
- Checked the README structure before editing.
- Ran git diff --check.