### PR TITLE
Add GoodMemory local-first agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Personal knowledge and notes integrations.
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
+- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory layer for Codex, Claude Code, and any MCP client. Durable SQLite and embedding-free recall work by default; memories are inspectable, correctable, exportable, and deletable, while writeback stays opt-in. Install: `npm install -g goodmemory@0.5.1`.)
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 
 ---

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Personal knowledge and notes integrations.
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
-- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory layer for Codex, Claude Code, and any MCP client. Durable SQLite and embedding-free recall work by default; memories are inspectable, correctable, exportable, and deletable, while writeback stays opt-in. Install: `npm install -g goodmemory@0.7.0`.)
+- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory layer for Codex, Claude Code, and any MCP client. Durable SQLite and embedding-free recall work by default; memories are inspectable, correctable, exportable, and deletable, while writeback stays opt-in. Install: `npm install -g goodmemory@0.7.1`.)
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 
 ---

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Personal knowledge and notes integrations.
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
-- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory layer for Codex, Claude Code, and any MCP client. Durable SQLite and embedding-free recall work by default; memories are inspectable, correctable, exportable, and deletable, while writeback stays opt-in. Install: `npm install -g goodmemory@0.5.1`.)
+- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory layer for Codex, Claude Code, and any MCP client. Durable SQLite and embedding-free recall work by default; memories are inspectable, correctable, exportable, and deletable, while writeback stays opt-in. Install: `npm install -g goodmemory@0.7.0`.)
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 
 ---

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -331,7 +331,7 @@
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
-- GoodMemory — https://github.com/hjqcan/GoodMemory（面向 Codex、Claude Code 与任意 MCP 客户端的本地优先、可审计记忆层。默认使用持久化 SQLite 与无嵌入召回；记忆可检查、纠正、导出和删除，写回需显式启用。安装：`npm install -g goodmemory@0.7.0`。）
+- GoodMemory — https://github.com/hjqcan/GoodMemory（面向 Codex、Claude Code 与任意 MCP 客户端的本地优先、可审计记忆层。默认使用持久化 SQLite 与无嵌入召回；记忆可检查、纠正、导出和删除，写回需显式启用。安装：`npm install -g goodmemory@0.7.1`。）
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -331,7 +331,7 @@
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
-- GoodMemory — https://github.com/hjqcan/GoodMemory（面向 Codex、Claude Code 与任意 MCP 客户端的本地优先、可审计记忆层。默认使用持久化 SQLite 与无嵌入召回；记忆可检查、纠正、导出和删除，写回需显式启用。安装：`npm install -g goodmemory@0.5.1`。）
+- GoodMemory — https://github.com/hjqcan/GoodMemory（面向 Codex、Claude Code 与任意 MCP 客户端的本地优先、可审计记忆层。默认使用持久化 SQLite 与无嵌入召回；记忆可检查、纠正、导出和删除，写回需显式启用。安装：`npm install -g goodmemory@0.7.0`。）
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -331,6 +331,7 @@
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
+- GoodMemory — https://github.com/hjqcan/GoodMemory（面向 Codex、Claude Code 与任意 MCP 客户端的本地优先、可审计记忆层。默认使用持久化 SQLite 与无嵌入召回；记忆可检查、纠正、导出和删除，写回需显式启用。安装：`npm install -g goodmemory@0.5.1`。）
 
 ---
 


### PR DESCRIPTION
## Summary

- add GoodMemory to the English Note Taking category
- add the corresponding Simplified Chinese entry
- include the current v0.7.1 install command

GoodMemory is a local-first, auditable memory layer for Codex, Claude Code, AI apps, and any stdio-capable MCP client. It uses durable SQLite and embedding-free recall by default, keeps memory inspectable/correctable/exportable/deletable, and requires explicit opt-in for MCP writeback.

## Verification

- confirmed the repository URL and published v0.7.1 install command
- checked both README diffs with `git diff --check`

This repository has no automated test suite; the change is limited to two catalog entries.