### PR TITLE
Add agentmail (OFAC sanctions) + sipi.bot (spend firewall) to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ Payments, market data, and finance tools.
 - CoinMarket — https://github.com/anjor/coinmarket-mcp-server
 - Chargebee (⭐) — https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol
 - DexPaprika (⭐) — https://github.com/donbagger/dexpaprika-mcp-server
+- agentmail (OFAC Sanctions Screening) — https://github.com/kindrat86/agentmail (OFAC sanctions screening for AI agents: 782 crypto wallets, 19,086 SDN names, 16 jurisdictions, under 100ms. MIT-licensed, self-hostable. `pip install sanctions-mcp`)
+- sipi.bot (Spend Firewall) — https://github.com/kindrat86/ai-agent-spend-firewall (Pre-spend firewall for autonomous AI agents: every transaction gets APPROVED, BLOCKED, or FLAGGED against per-tx caps, velocity rules, and merchant allowlists. MCP-native)
 - Mercado Pago — https://mcp.mercadopago.com/
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit


### PR DESCRIPTION
Adds two production MCP servers to the Finance category:

**agentmail** — OFAC sanctions screening for AI agents that transact autonomously. 782 crypto wallets, 19,086 SDN names, 16 jurisdictions, under 100ms. MIT-licensed. Live at sanctionsai.dev.

**sipi.bot** — Pre-spend firewall for autonomous AI agents. APPROVED/BLOCKED/FLAGGED per transaction. Live at sipi.bot.