### PR TITLE
Add Vaaya to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ Single MCP endpoints that expose many integrations.
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy
 - MCP Aggregator / Combine — https://github.com/nazar256/combine-mcp
 - Magg — https://github.com/sitbon/magg
+- Vaaya — https://github.com/vaaya-ai/vaaya-mcp — One card for hundreds of paid services: web search & scraping, research, lead enrichment, media & video generation, code sandboxes, browser automation, email. Pay per call, no per-vendor signups or API keys.
 
 ---
 


### PR DESCRIPTION
Adds Vaaya to the Aggregators category. Vaaya (https://vaaya.ai) is a remote MCP server that gives an AI agent a prepaid card to pay per call for hundreds of paid services — search, research, lead enrichment, media & video generation, code sandboxes, browser automation, email — with no per-vendor signups or API keys. Published to the official MCP Registry as ai.vaaya/mcp.