### PR TITLE
Add Agent Web Search MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ Web fetching, scraping, and search.
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
+- [Agent Web Search MCP](https://hermes-api.tiagohanna.com/) - DuckDuckGo web search and URL fetch MCP server. Free tier (7 req/IP/day, no API key needed). ([GitHub](https://github.com/tiagohanna123/agent-web-search-mcp))
+
+---
 
 ---
 


### PR DESCRIPTION
Adding [Agent Web Search MCP](https://hermes-api.tiagohanna.com/) to Search & Web category.

A DuckDuckGo-based web search and URL fetch MCP server. Free tier (7 req/IP/day, no API key needed). Pro tier (unlimited, R$50). Remote HTTP server.