### PR TITLE
Add Darkmoon (GPL-3.0 autonomous pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ BTW, we provide a [full list of MCP (Master Control Program) Servers](https://gi
 
 ## Tutorials
 
+* [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI pentest platform and MCP host, covering web, API, Active Directory and Kubernetes, with proof of exploitation.
 * [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
 * [Setup Claude Desktop App to Use a SQLite Database](https://youtu.be/wxCCzo9dGj0)
 


### PR DESCRIPTION
Hi, thanks for maintaining this list. Adding Darkmoon, a GPL-3.0 autonomous penetration testing platform covering Active Directory and Kubernetes alongside web and APIs. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: our project. Happy to adjust or close if not a fit.