### PR TITLE
Add UIZZE MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- UIZZE — https://uizze.com — Hosted MCP for coding agents to search 800,000+ real web and iOS screens before implementing or reviewing a UI.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
## What changed

- Added UIZZE to the Development Tools category.

## Why

UIZZE is a hosted MCP service for coding agents to search real web and iOS interface references before implementing or reviewing a UI.

## Checks

- Searched the repository and existing pull requests for duplicates.
- Verified `https://uizze.com` returns HTTP 200.
- Verified the hosted MCP endpoint exposes Streamable HTTP at `https://uizze.com/mcp`.
- Ran `git diff --check`.
