### PR TITLE
Add GetABrain to Research & Data category

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Papers, datasets, and domain data.
 - Ancestry — https://github.com/reeeeemo/ancestry-mcp
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
+- GetABrain (real human judgment as agent tools) — https://www.npmjs.com/package/@getabrain/mcp-server
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
 
 ---


### PR DESCRIPTION
GetABrain gives AI agents access to real human judgment (A/B tests, ratings, reviews, sentiment, media capture - 16 types) via an MCP server, REST API, and SDKs. Free synthetic test mode; pay per response from $0.05. npm: https://www.npmjs.com/package/@getabrain/mcp-server