### PR TITLE
Add Chainflip Broker as a Service to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- Chainflip Broker as a Service (native cross-chain swaps via the Chainflip protocol: quotes, simple or DCA swaps, status tracking, hosted remote MCP, no API key) — https://github.com/CumpsD/broker-as-a-service
 
 ---
 


### PR DESCRIPTION
Adds Chainflip Broker as a Service to Category: Finance.

- Native cross-chain cryptocurrency swaps via the Chainflip protocol: quotes, simple or DCA swap execution, and swap status tracking.
- Hosted remote MCP, Streamable HTTP at `https://chainflip-broker.io/mcp`, open, no API key.
- Listed in the official MCP Registry as `io.chainflip-broker/crypto-swap`.
- Docs: https://docs.chainflip-broker.io/resources/ai-documentation/
