### PR TITLE
Add Formo analytics MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- Formo (product and onchain analytics) — https://docs.formo.so/mcp/overview — https://formo.so
 
 ---
 


### PR DESCRIPTION
Adds [Formo](https://formo.so) to Research & Data.

Formo exposes project-scoped product and onchain analytics through an official hosted MCP server.

Documentation: https://docs.formo.so/mcp/overview

Validation: destination links resolve and the Markdown diff passes `git diff --check`.

Disclosure: I maintain Formo.
