### PR TITLE
Add ChurnLens MCP server to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- ChurnLens (buyer-side SaaS due diligence: NRR/GRR and the spread that exposes churn masked by expansion, HHI revenue concentration, zombie MRR, LTV:CAC, composite health score; keyless, hosted) — https://github.com/kindrat86/churnlens-mcp
 
 ---
 


### PR DESCRIPTION
Adds the ChurnLens MCP server to the **Finance** category, following the existing one-line format.

**Repo:** https://github.com/kindrat86/churnlens-mcp
**Live endpoint:** https://churnlens.site/api/mcp (streamable HTTP, MCP 2024-11-05)

Buyer-side SaaS due-diligence maths for acquirers and M&A analysts. Six tools: net and gross revenue retention (plus the NRR−GRR spread that exposes churn masked by expansion), HHI revenue concentration with whale detection, dormant "zombie" MRR, gross-margin-adjusted LTV:CAC with payback, and a composite 0–100 health score.

Keyless, no account, nothing stored. Scoring thresholds are labelled as bands rather than measured data, and the implementation is open source under MIT ([saas-metrics](https://github.com/kindrat86/saas-metrics)), so any result reproduces independently.