### PR TITLE
Update x402engine-mcp listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Payments, market data, and finance tools.
 - PayPal (⭐) — https://github.com/paypal/agent-toolkit
 - Stripe (⭐) — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
-- x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
+- x402engine-mcp (108 x402 pay-per-call APIs, including 72 LLMs plus media, web, code, crypto, audio, travel, and IPFS) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
 
 ---


### PR DESCRIPTION
Updates the existing x402engine-mcp entry to reflect the current 108 x402-payable APIs, including 72 LLMs plus media, web, code, crypto, audio, travel, and IPFS.