### PR TITLE
Add OpenPost to Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Social platforms integration.
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp
 - X/Twitter — https://github.com/mbelinky/x-mcp-server
 - Social Neuron (52 MCP tools for AI-powered social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning) — https://github.com/socialneuron/mcp-server [npm: @socialneuron/mcp-server]
+- OpenPost (open-source, self-hosted social publishing and scheduling with authenticated Streamable HTTP and stdio MCP access for destination-specific content, media reuse, validation, scheduling, publishing, and delivery status) — https://github.com/rodrgds/openpost
 
 ---
 


### PR DESCRIPTION
Adds OpenPost's authenticated MCP server to Social Media, covering its self-hosted deployment and core publishing workflow.

Disclosure: I maintain OpenPost.