### PR TITLE
Add DC Hub MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Payments, market data, and finance tools.
 
 ## Category: Research & Data (🧬)
 
-- DC Hub — https://github.com/azmartone67/dchub-mcp-server (live data-center, power-grid, energy, interconnection-queue, fiber & gas intelligence for AI agents — DC Hub Power Index across 311 markets, ISO grid telemetry, fiber routes; 79 tools, free tier, no signup)
+- DC Hub — https://github.com/azmartone67/dchub-mcp-server (live data-center, power-grid, energy, interconnection-queue, fiber & gas intelligence for AI agents — DC Hub Power Index across 300+ markets, ISO grid telemetry, fiber routes; 82 tools, free tier, no signup)
 Papers, datasets, and domain data.
 
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server

--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Payments, market data, and finance tools.
 
 ## Category: Research & Data (🧬)
 
+- DC Hub — https://github.com/azmartone67/dchub-mcp-server (live data-center, power-grid, energy, interconnection-queue, fiber & gas intelligence for AI agents — DC Hub Power Index across 311 markets, ISO grid telemetry, fiber routes; 79 tools, free tier, no signup)
 Papers, datasets, and domain data.
 
 - ArXiv — https://github.com/blazickjp/arxiv-mcp-server


### PR DESCRIPTION
Adds **DC Hub** — a remote MCP server (streamable-http at https://dchub.cloud/mcp).

Live data-center, power-grid, energy, interconnection-queue, fiber, natural-gas & M&A intelligence for AI agents — DC Hub Power Index (311 markets), ISO grid telemetry, fiber routes, 79 tools. Remote MCP at https://dchub.cloud/mcp — query and cite.

Repo: https://github.com/azmartone67/dchub-mcp-server · License CC-BY-4.0 · In the official MCP registry.