### PR TITLE
Add SocialClaw to Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Social platforms integration.
 
 - BlueSky — https://github.com/keturiosakys/bluesky-context-server
 - YouTube — https://github.com/anaisbetts/mcp-youtube and https://github.com/kimtaeyoon83/mcp-server-youtube-transcript
+- SocialClaw — https://github.com/ndesv21/socialclaw
 - Spotify — https://github.com/varunneal/spotify-mcp
 - TikTok — https://github.com/Seym0n/tiktok-mcp
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp


### PR DESCRIPTION
Adds [SocialClaw](https://github.com/ndesv21/socialclaw) — MCP server for scheduling/publishing social posts across X, LinkedIn, Instagram, Facebook Pages, TikTok, YouTube, Reddit, Pinterest, Discord, Telegram, and WordPress.