### PR TITLE
Add OSRS Calc MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Social platforms integration.
 Game engines and tooling.
 
 - Unity Engine (various) — https://github.com/IvanMurzak/Unity-MCP, https://github.com/CoderGamester/mcp-unity, https://github.com/codemaestroai/advanced-unity-mcp
+- OSRS Calc (⭐) — https://github.com/rocnubie/osrs-calc-mcp (read-only Old School RuneScape skill planning, combat, prices, and wiki reference workflows; use https://osrs-calc.com for current values) [Registry: `io.github.rocnubie/osrs-calc-mcp`]
 
 ---
 


### PR DESCRIPTION
## Summary

- Add the official OSRS Calc MCP server to Gaming.
- Describe its read-only Old School RuneScape planning and reference scope.
- Link the live site for current values and include the official MCP Registry name.

## Verification

- Repository is public, MIT-licensed, and uses stdio on Node.js 18+.
- https://osrs-calc.com responds successfully.
- io.github.rocnubie/osrs-calc-mcp version 0.1.0 is active in the official MCP Registry.