### PR TITLE
Add Tier Maker List MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Social platforms integration.
 
 Game engines and tooling.
 
+- Tier Maker List (⭐) — https://github.com/rocnubie/tiermakerlist-mcp (read-only tier-list editing, local draft, sharing, and PNG/JSON export reference; use https://tiermakerlist.com for the live editor and current templates) [Registry: `io.github.rocnubie/tiermakerlist-mcp`]
 - Unity Engine (various) — https://github.com/IvanMurzak/Unity-MCP, https://github.com/CoderGamester/mcp-unity, https://github.com/codemaestroai/advanced-unity-mcp
 
 ---


### PR DESCRIPTION
## Summary

- Add the official Tier Maker List MCP server to Gaming.
- Describe its read-only editor, local draft, sharing, and export reference.
- Link clients to the live editor for current templates and include the official MCP Registry name.

## Verification

- Repository is public, MIT-licensed, and uses stdio on Node.js 18+.
- https://tiermakerlist.com responds successfully.
- io.github.rocnubie/tiermakerlist-mcp version 0.1.0 is active in the official MCP Registry.