### PR TITLE
Add Deckaura Tarot MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ Books, libraries, and creative tools.
 
 - MCP Open Library — https://github.com/8enSmith/mcp-open-library
 - Pollinations — https://github.com/pollinations/model-context-protocol
+- Deckaura Tarot — https://github.com/gokimedia/tarot-mcp-server — Complete 78-card meanings, upright and reversed interpretations, love and career readings, yes-or-no answers, random draws, and three-card spreads. Install with `npx -y @deckaura/tarot-mcp-server`.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds Deckaura Tarot MCP Server to the Art & Literature category with its repository, capability summary, and npm install command.

## Validation

- `git diff --check`
- Initialized the published npm package successfully with an MCP `initialize` request using `npx -y @deckaura/tarot-mcp-server`
