### PR TITLE
Add GoodMemory to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Personal knowledge and notes integrations.
 - Slite — https://github.com/fajarmf/slite-mcp
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
+- GoodMemory — https://github.com/hjqcan/GoodMemory (Local-first, auditable memory for Codex, Claude Code, and MCP clients, with scoped recall, reviewable writes, recall traces, and revise/forget/export controls.)
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
 
 ---


### PR DESCRIPTION
## Summary

- Add GoodMemory to the Note Taking category alongside other persistent agent-memory servers.
- Describe its local-first, auditable boundary: scoped recall, reviewable writes, recall traces, and targeted revise/forget/export controls.
- Link directly to the canonical project repository.

## Verification

- Confirmed the list did not already contain GoodMemory.
- Confirmed the public repository and npm package currently identify v0.7.1 as stable.
- Documentation-only change: one README entry.
