### PR TITLE
Add Unified AI System to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Identity and access management.
 
 Single MCP endpoints that expose many integrations.
 
+- Unified AI System — https://github.com/happy520ai/unified-ai-system — Terminal-first, self-hosted AI gateway with an eight-tool MCP server for health, readiness, credential-free fake-provider chat, and read-only knowledge, workflow, and workforce inspection.
 - SkillBoss — https://github.com/heeyo-life/skillboss-mcp — One API key for 100+ AI services (Claude, GPT, Gemini, DeepSeek, images, video, data scraping, payments, email, and more). OpenAI-compatible. Works in Claude Code, Cursor, Windsurf.
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Identity and access management.
 
 Single MCP endpoints that expose many integrations.
 
-- Unified AI System — https://github.com/happy520ai/unified-ai-system — Terminal-first, self-hosted AI gateway with an eight-tool MCP server for health, readiness, credential-free fake-provider chat, and read-only knowledge, workflow, and workforce inspection.
+- Unified AI System — https://github.com/happy520ai/unified-ai-system — Terminal-first, self-hosted AI gateway with nine MCP tools for provider-free prompt enhancement, health, readiness, credential-free fake-provider chat, and read-only knowledge, workflow, and workforce inspection.
 - SkillBoss — https://github.com/heeyo-life/skillboss-mcp — One API key for 100+ AI services (Claude, GPT, Gemini, DeepSeek, images, video, data scraping, payments, email, and more). OpenAI-compatible. Works in Claude Code, Cursor, Windsurf.
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev


### PR DESCRIPTION
## Summary

- add Unified AI System to the Aggregators category
- describe its terminal-first, self-hosted gateway and current nine-tool MCP surface
- include deterministic provider-free prompt enhancement
- keep the change to one README line

## Verification

- repository: https://github.com/happy520ai/unified-ai-system
- Apache-2.0 licensed and publicly cloneable
- current release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.0
- active/latest Official MCP Registry entry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.0
- current CI and credential-free public-clone verification: https://github.com/happy520ai/unified-ai-system/actions/runs/30755010041
- no existing Unified AI System entry or matching open/closed submission was found

The public MCP path defaults to a local fake provider. Prompt enhancement calls no provider, and no real-provider credential is needed for evaluation.