### PR TITLE
Add Talivia Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Charting and diagram tools.
 - ECharts — https://github.com/hustcc/mcp-echarts
 - Mermaid — https://github.com/hustcc/mcp-mermaid
 - unified-diff-mcp — https://github.com/gorosun/unified-diff-mcp
+- Talivia Agent Kit (official remote and local MCP server, CLI, and Agent Skill for installing revenue-first website analytics, verifying live events, and connecting traffic to payment attribution; remote MCP: https://talivia.com/mcp) — https://github.com/talivia-group/agent [npm: @talivia/agent]
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -478,6 +478,7 @@ AI モデルおよび ML サービスとの統合。
 - ECharts — https://github.com/hustcc/mcp-echarts
 - Mermaid — https://github.com/hustcc/mcp-mermaid
 - unified-diff-mcp — https://github.com/gorosun/unified-diff-mcp
+- Talivia Agent Kit（収益重視の Web サイト分析の導入、ライブイベントの検証、トラフィックと決済アトリビューションの接続に対応する公式リモート／ローカル MCP サーバー、CLI、Agent Skill。リモート MCP: https://talivia.com/mcp）— https://github.com/talivia-group/agent [npm: @talivia/agent]
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -346,6 +346,7 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 ## 카테고리: 데이터 시각화 (📊)
 
 - VegaLite — https://github.com/isaacwasserman/mcp-vegalite-server
+- Talivia Agent Kit (수익 중심 웹사이트 분석 설치, 실시간 이벤트 검증, 트래픽과 결제 어트리뷰션 연결을 지원하는 공식 원격/로컬 MCP 서버, CLI, Agent Skill. 원격 MCP: https://talivia.com/mcp) — https://github.com/talivia-group/agent [npm: @talivia/agent]
 
 ---
 
@@ -390,5 +391,4 @@ MCP 서버를 검색、설치、관리 및 작업하는 데 도움이 되는 유
 - 신뢰할 수 없는 커뮤니티 서버는 컨테이너 또는 VM 같은 격리 환경에서 실행하십시오。
 - 프로덕션 환경에서는 공식(⭐) 구현을 우선 사용하십시오。
 - 각 서버의 리포지토리에서 전송 방식(stdio, SSE, HTTP)、인증 및 예제 클라이언트를 확인하십시오。
-
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -466,6 +466,7 @@ Shell、操作系统与任务自动化相关。
 - ECharts — https://github.com/hustcc/mcp-echarts
 - Mermaid — https://github.com/hustcc/mcp-mermaid
 - unified-diff-mcp — https://github.com/gorosun/unified-diff-mcp
+- Talivia Agent Kit（官方远程与本地 MCP 服务器、CLI 和 Agent Skill，用于安装以收入为核心的网站分析、验证实时事件，并将流量与支付归因关联；远程 MCP：https://talivia.com/mcp）— https://github.com/talivia-group/agent [npm: @talivia/agent]
 
 ---
 
@@ -646,4 +647,3 @@ Shell、操作系统与任务自动化相关。
 - 在生产环境中优先使用官方厂商维护的服务器（标注为 ⭐）。
 - 查阅每个服务器仓库，了解其支持的传输方式（stdio、SSE、HTTP）、鉴权方式与示例客户端。
 - 该生态系统发展迅速，新的服务器、客户端和框架不断加入。维护者请确保仓库包含清晰的安装与安全说明。
-

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -480,6 +480,7 @@ AI 與機器學習服務整合：
 - ECharts — https://github.com/hustcc/mcp-echarts
 - Mermaid — https://github.com/hustcc/mcp-mermaid
 - unified-diff-mcp — https://github.com/gorosun/unified-diff-mcp
+- Talivia Agent Kit（官方遠端與本地 MCP 伺服器、CLI 和 Agent Skill，用於安裝以營收為核心的網站分析、驗證即時事件，並將流量與付款歸因連結；遠端 MCP：https://talivia.com/mcp）— https://github.com/talivia-group/agent [npm: @talivia/agent]
 
 ---
 
@@ -662,5 +663,4 @@ AI 與機器學習服務整合：
 - 正式環境建議優先使用官方廠商維護的伺服器（標註為 ⭐）。
 - 檢視各伺服器倉庫以了解支援之傳輸方式（stdio、SSE、HTTP）、認證方式與範例用戶端。
 - 此生態系迅速演進，新伺服器、用戶端與框架經常加入；維護者請確保倉庫附有清楚的安裝與安全說明。
-
 


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

This adds equivalent entries to the English, Japanese, Korean, Simplified Chinese, and Traditional Chinese catalogs.