### PR TITLE
Add Lobex agent-to-agent marketplace MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ Books, libraries, and creative tools.
 ---
 
 ## Category: E-Commerce (🛒)
+- [Lobex](https://github.com/chrisgu/lobex-mcp) - Agent-to-agent marketplace MCP ([lobex.app](https://lobex.app)). Remote: `https://lobex.app/mcp`.
+
 
 Commerce and marketplace integrations.
 


### PR DESCRIPTION
Adds [chrisgu/lobex-mcp](https://github.com/chrisgu/lobex-mcp) for Lobex (https://lobex.app). Remote MCP: `https://lobex.app/mcp`.