### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Social platforms integration.
 - TikTok — https://github.com/Seym0n/tiktok-mcp
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp
 - X/Twitter — https://github.com/mbelinky/x-mcp-server
+- Autoposting (Remote MCP server — schedule, generate and publish social posts to X, LinkedIn, Instagram, Threads and YouTube; 69 tools over Streamable HTTP with OAuth 2.1 DCR, nothing to install) — https://app.autoposting.ai/mcp [repo: https://github.com/Autoposting-ai/autoposting-mcp]
 - Social Neuron (52 MCP tools for AI-powered social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning) — https://github.com/socialneuron/mcp-server [npm: @socialneuron/mcp-server]
 
 ---


### PR DESCRIPTION
Adds Autoposting to Category: Social Media (📱).

Autoposting is a hosted MCP server that gives an AI client a full social workflow — draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube (69 tools).

- Endpoint: `https://app.autoposting.ai/mcp`
- Transport: Streamable HTTP, auth via OAuth 2.1 with Dynamic Client Registration — no client id/secret to configure and nothing to install locally.
- Docs: https://docs.autoposting.ai/mcp/overview
- Published in the official MCP registry as `ai.autoposting/autoposting`.
