### PR TITLE
Add MailKite to Communication category

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- MailKite (⭐) — https://github.com/mailkite/mailkite-mcp
 
 ---
 


### PR DESCRIPTION
Adds **MailKite** to `## Category: Communication (💬)`.

### Entry

```
- MailKite (⭐) — https://github.com/mailkite/mailkite-mcp
```

### What it is

MailKite gives an AI agent its **own real email inbox** — inbound mail arrives as structured tool calls (no IMAP polling), and the agent sends from a domain you verify (SPF/DKIM). Most email MCP servers wrap a human's existing Gmail/Outlook account or only validate addresses; this one provisions the mailbox for the agent itself.

| | |
|---|---|
| Transport | Streamable HTTP (hosted remote) — `https://mcp.mailkite.dev/mcp` |
| Auth | OAuth 2.0, dynamic client registration, `/.well-known` discovery |
| Tools | 60+ — send + batch, attachments, inbound routes, webhooks (set/test), domain registration + DNS verification, templates, contact lists, broadcasts, message search |
| License | MIT |
| Docs | https://mailkite.dev/docs · agents: https://mailkite.dev/docs/ai-agents |

Marked `(⭐)` per the legend ("Official protocol implementation") — this is the vendor's own server, same basis as the `LINE Official Account (⭐)` and `Carbon Voice (⭐)` entries above it.

### Notes

- Appended to the end of the Communication list, matching how that section is ordered (it isn't alphabetical).
- Only `README.md` is touched, matching the convention in recently merged add-PRs (#132, #97, #55).
- The listing points at the hosted remote endpoint deliberately. A `npx @mailkite/mcp` stdio package also exists, but the current published version has a startup bug we're mid-fix, so it isn't advertised here.
- Live right now if you want to check: `GET https://mcp.mailkite.dev/mcp` → 405 (POST-only, as expected), and `/.well-known/oauth-protected-resource` serves valid RFC 9728 metadata.

### Disclosure

I work on MailKite — this is a self-submission. This PR was prepared with AI assistance; the entry, the endpoint, and the license were verified against the live server before opening.
