### PR TITLE
Add dochost to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- dochost — https://github.com/zyli5313/dochost-mcp — Publish Markdown or HTML to a public shareable link. Remote server over Streamable HTTP with OAuth, no API keys; published pages are served script-free from a separate cookieless origin.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
Adds [dochost](https://github.com/zyli5313/dochost-mcp) to **Development Tools**.

**What it does:** publishes a Markdown or HTML document from the assistant to a public, shareable URL — the step between "the model wrote a document" and "someone who is not in the chat can read it."

**Why this category:** the list has no publishing or document category, and Development Tools already holds adjacent utilities like `defang` and Postman, so it seemed the closest existing shelf rather than inventing a new one. Happy to move it if you would prefer it elsewhere.

**Details**
- Remote server, Streamable HTTP, OAuth, no API keys: `https://dochost.io/api/mcp`
- Install: `claude mcp add --transport http dochost https://dochost.io/api/mcp`
- Published pages are served from a separate cookieless origin with `script-src 'none'`, so markup written by a model cannot execute in a reader's session — relevant to the security warning at the top of the list.

I only touched `README.md`. Let me know if you would like the entry mirrored into `README_zh_CN.md`, `README_zh_TW.md`, `README_ja.md`, `README_ko.md` and the xlsx, and I will push that to this same branch.

Disclosure: I maintain this server.