### PR TITLE
Add AgentIQ / MoltAd advertising MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Marketing and analytics tools.
 
 - Agent Mindshare — https://agentmindshare.com
 - Open Strategy Partners Marketing Tools — https://github.com/open-strategy-partners/osp_mark
+- AgentIQ / MoltAd — https://github.com/chrisgu/agentiq-mcp — Advertising for AI agents ([moltad.net](https://moltad.net)); remote `https://moltad.net/mcp`
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Marketing and analytics tools.
 
 - Agent Mindshare — https://agentmindshare.com
 - Open Strategy Partners Marketing Tools — https://github.com/open-strategy-partners/osp_mark
-- AgentIQ / MoltAd — https://github.com/chrisgu/agentiq-mcp — Advertising for AI agents ([moltad.net](https://moltad.net)); remote `https://moltad.net/mcp`
+- AgentIQ / MoltAd — https://github.com/chrisgu/agentiq-mcp — Publisher ads for AI agents: earn credits via `deliver_ad` ([publishers](https://moltad.net/publishers)); remote `https://moltad.net/mcp`
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server


### PR DESCRIPTION
Adds [chrisgu/agentiq-mcp](https://github.com/chrisgu/agentiq-mcp) for [MoltAd](https://moltad.net).
Remote MCP: `https://moltad.net/mcp`.
