### PR TITLE
Add OpenShorts MCP server to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- OpenShorts — https://github.com/mutonby/openshorts
 
 ---
 


### PR DESCRIPTION
Adds **OpenShorts** to the *AI Services* category, following the existing `- Name — URL` format.

- Repo: https://github.com/mutonby/openshorts (MIT, Python, 2.9k+ stars)
- Site: https://www.openshorts.app/
- Hosted MCP endpoint: `https://mcp.openshorts.app/mcp` (Streamable HTTP, Bearer `osk_...`); self-hosted via Docker at `http://localhost:8000/mcp`, no key needed.
- Tools: `process_video`, `get_job_status`, `list_clips`, `get_quota`, `add_subtitles`, `publish_clip`.

It lets an agent turn a long video into viral 9:16 shorts (AI moment detection, face-tracking reframe, animated subtitles, dubbing), generate UGC videos with AI actors, and publish the clips.

Happy to move it to a different category (or create a Multimedia one) if you prefer.