### PR TITLE
Add Motion Menu to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
+- Motion Menu — https://motion-menu-two.vercel.app — 596 motion/3D UI patterns as ready HTML/CSS/JS over a streamable-http MCP endpoint (https://motion-menu-two.vercel.app/api/mcp). Tools to recommend, validate, and compose patterns into a page. 26 patterns free, no key; rest is $149 once, lifetime.
 - many others in Community Servers and Official Servers
 
 ---

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
-- Motion Menu — https://motion-menu-two.vercel.app — 596 motion/3D UI patterns as ready HTML/CSS/JS over a streamable-http MCP endpoint (https://motion-menu-two.vercel.app/api/mcp). Tools to recommend, validate, and compose patterns into a page. 26 patterns free, no key; rest is $149 once, lifetime.
+- Motion Menu — https://www.motionmenu.ca — 597 motion/3D UI patterns as ready HTML/CSS/JS over a streamable-http MCP endpoint (https://www.motionmenu.ca/api/mcp). Tools to recommend, validate, and compose patterns into a page. 26 patterns free, no key; rest is $149 once, lifetime.
 - many others in Community Servers and Official Servers
 
 ---

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Developer-focused MCP servers and tools.
 - DefangLabs/defang — https://github.com/DefangLabs/defang
 - jarp-mcp — https://github.com/tersePrompts/jarp-mcp
 - HendryAvila/Hoofy — https://github.com/HendryAvila/Hoofy — Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary.
-- Motion Menu — https://www.motionmenu.ca — 597 motion/3D UI patterns as ready HTML/CSS/JS over a streamable-http MCP endpoint (https://www.motionmenu.ca/api/mcp). Tools to recommend, validate, and compose patterns into a page. 26 patterns free, no key; rest is $149 once, lifetime.
+- Motion Menu — https://www.motionmenu.ca — 597 motion/3D UI patterns as ready HTML/CSS/JS over a streamable-http MCP endpoint (https://www.motionmenu.ca/api/mcp). Tools to recommend, validate, and compose patterns into a page. the entire library is free — no key, no card.
 - many others in Community Servers and Official Servers
 
 ---


### PR DESCRIPTION
Adds Motion Menu — a remote streamable-http MCP server serving 596 motion/3D UI patterns (scroll-driven WebGL, shader passes, spring choreography) as ready HTML/CSS/JS, with tools to recommend, validate, and compose patterns into a page.

- Endpoint: https://motion-menu-two.vercel.app/api/mcp
- Free tier: 26 patterns, no key required
- Paid: $149 once, lifetime, no subscription
- Already listed in the official MCP registry as `io.github.dev55acc-ai/motion-menu`

Appended to the Development Tools category, matching the existing non-GitHub-repo entry style already in that list (e.g. Agent Mindshare, Render, Probe.dev).