### PR TITLE
Add Parallel Search MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Web fetching, scraping, and search.
 - Fetch — https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
 - Kagi Search — https://github.com/ac3xx/mcp-servers-kagi
 - Exa Search (⭐) — https://github.com/exa-labs/exa-mcp-server
+- Parallel Search MCP (⭐) — https://docs.parallel.ai/integrations/mcp/search-mcp - Hosted web search and page retrieval at `https://search.parallel.ai/mcp`, with no API key required.
 - NYTimes — https://github.com/angheljf/nyt
 - Google News — https://github.com/ChanMeng666/server-google-news
 - Scrapeless — https://github.com/scrapeless-ai/scrapeless-mcp-server


### PR DESCRIPTION
## What changed

Adds one Parallel Search MCP entry to the existing Search & Web category. The line points to the public setup documentation and includes the hosted endpoint so readers can connect without an API key.

## Validation

- confirmed the documentation URL returns HTTP 200
- completed a live MCP handshake and confirmed `web_search` and `web_fetch`
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.
