### PR TITLE
Add stipend to Category: Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- stipend (non-custodial USDC wallet on Base for agents; per-transaction, per-day and per-counterparty spending limits enforced in code, not in a prompt) — https://github.com/stipend-sh/stipend
 
 ---
 


### PR DESCRIPTION
Adds one entry to **Category: Finance (💹)**, in the same `- Name (parenthetical) — url` form as its neighbours.

[stipend](https://github.com/stipend-sh/stipend) — non-custodial USDC wallet on Base that an AI agent installs by itself. Per-transaction, per-day and per-counterparty caps plus a destination allowlist are enforced in code between the decision and the signature, not in a prompt.

MCP server `stipend mcp`: JSON-RPC over stdio, 7 tools (`stipend_address`, `stipend_balance`, `stipend_check`, `stipend_pay`, `stipend_earnings`, `stipend_report`, `stipend_recover`). Python, Apache-2.0, not audited.
