### PR TITLE
Add three scientific-simulation MCP servers (Research & Data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,9 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- Blender Optics Simulator (optical bench simulation) — https://github.com/emircbngl/blender-optics-simulator
+- TARHAN (semiconductor & fuel-cell simulation) — https://github.com/emircbngl/tarhan
+- dhm-hybrid (holographic microscopy, quantitative phase) — https://github.com/emircbngl/dhm-hybrid
 
 ---
 


### PR DESCRIPTION
Adds three MCP servers I maintain — research instruments rather than API wrappers.

- **Blender Optics Simulator** — an optical bench inside Blender an agent drives over MCP, reading element poses, beam paths and detector readings as ground truth to align mirrors or close an adaptive-optics loop. GPL-3.0, DOI 10.5281/zenodo.20778997.
- **TARHAN** — semiconductor drift-diffusion, fuel cells and electrochemistry, where every capability is pinned to a reproduction test against printed textbook values and blocked capabilities exit non-zero rather than returning a plausible number. Apache-2.0, DOI 10.5281/zenodo.21761218. Pre-alpha, and the README says so.
- **dhm-hybrid** — digital holographic microscopy: off-axis hologram reconstruction and quantitative phase imaging of live cells, driveable headlessly.

**On the section:** I used Research & Data as the closest fit, though its blurb says "papers, datasets, and domain data" and these are instruments rather than data sources — Probe.dev in the same section is the precedent I went by. Happy to move them wherever you'd prefer, or to split this into three PRs.