### PR TITLE
Add harvis.dev to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Cloud vendors and orchestration.
 - Tinybird (⭐) — https://github.com/tinybirdco/mcp-tinybird
 - Google Cloud Run — https://github.com/GoogleCloudPlatform/cloud-run-mcp
 - Render — https://render.com/docs/mcp-server
+- harvis.dev (remote, static site deploys) — https://github.com/harvis-io/harvis-dev-mcp
 
 ---
 


### PR DESCRIPTION
Adds harvis.dev to Category: Cloud Platforms (after Render, which is a comparable deploy platform entry).

harvis.dev is a remote MCP server (Streamable HTTP at `https://harvis.dev/api/mcp`) with a `deploy_site` tool that publishes static files and returns a live URL in seconds — no account or API key. Repo: https://github.com/harvis-io/harvis-dev-mcp · official MCP Registry: `dev.harvis/harvis`.

Disclosure: I built harvis.dev.