### PR TITLE
Add AgentWork outcome routing MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Papers, datasets, and domain data.
 
 AI model & ML service integrations.
 
+- AgentWork — https://github.com/mitchellOpZero/agentwork-api — Free remote MCP for agents blocked outside their current capabilities: submit a privacy-safe goal, blocker, constraints, acceptance test, and frequency, then retrieve one evidence-backed completion route or an honest no-credible-route result.
 - Agentset AI — https://github.com/agentset-ai/mcp-server
 - NeuroLink — https://github.com/juspay/neurolink
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai


### PR DESCRIPTION
Adds the public AgentWork remote MCP under AI Services.

AgentWork accepts a privacy-safe blocked-outcome brief and returns one evidence-backed completion route or an honest `no_credible_route` result. The discovery pilot is free.

- Public docs: https://github.com/mitchellOpZero/agentwork-api
- Remote MCP: https://agent-work-api.agentwork-market.workers.dev/mcp
- Live API contract: https://agent-work-api.agentwork-market.workers.dev/openapi.json

The description intentionally does not claim validated demand or guaranteed completion. `git diff --check` passes.