### PR TITLE
Add LWC memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- LWC — https://github.com/JanYork/llm-wiki-cli (Source-grounded project memory for AI agents with citations, provenance, SQLite/FTS5 retrieval, optional document and code graphs, and a bounded read-only MCP server.)
 
 ---
 


### PR DESCRIPTION
Adds LWC to the Note Taking category as source-grounded project memory for AI agents, including citations, provenance, SQLite/FTS5 retrieval, optional document/code graphs, and a bounded read-only MCP server.

README-only one-line addition; repository link verified.