### PR TITLE
Add SandBase Harness to Sandbox & Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Secure sandbox environments for code execution.
 - Microsandbox (⭐) — https://github.com/microsandbox/microsandbox
 - E2B (⭐) — https://github.com/e2b-dev/mcp-server
 - Docker (QuantGeekDev) — https://github.com/QuantGeekDev/docker-mcp
+- SandBase Harness — https://github.com/sandbaseai/sandbase-harness — Model-agnostic managed agent runtime with MCP tools for persistent, sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay.
 
 ---
 


### PR DESCRIPTION
## Summary

Add SandBase Harness to the Sandbox & Virtualization category.

SandBase Harness is an open-source, model-agnostic managed agent runtime. Its MCP stdio bridge exposes persistent sandboxed sessions, streamed turns, artifacts, cancellation, audit, and replay to MCP clients.

## Validation

- verified the upstream repository and MCP integration documentation
- kept the existing list format
- ran `git diff --check`

Disclosure: this contribution was prepared with AI assistance for the SandBase project.