### PR TITLE
Add Cheaplane to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- Cheaplane — https://github.com/millennialdreamer/cheaplane
 
 ---
 


### PR DESCRIPTION
Adds [Cheaplane](https://github.com/millennialdreamer/cheaplane) to the **AI Services** category, matching the existing `- Name — URL` format.

Cheaplane is a single-file Python MCP server that delegates replaceable grunt work (boilerplate, formatting, translation, long-document summarizing) from a premium agent to cheap models behind a local LiteLLM proxy, auto-routing by task type. Delegated calls run in a separate process so the subscription session and the API credentials never share an environment. MIT licensed.

One line added, no other changes.