### PR TITLE
Add SandBase CLI to Server Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Server Managers:
 - yamcp — Model Context Workspace Manager — https://github.com/hamidra/yamcp
 - ToolHive — Lightweight utility to simplify deployment & management — https://github.com/StacklokLabs/toolhive
 - MCP Installer — https://github.com/anaisbetts/mcp-installer
+- SandBase CLI — Connects 17+ AI clients to a hosted MCP gateway with OAuth, ownership-aware configuration, rollback, diagnostics, and native Skill setup — https://github.com/sandbaseai/cli
 
 Other utilities:
 - Secure Fetch — secure fetch to prevent access to local resources — https://github.com/appsec-innovation-labs/secure-mcp-fetch


### PR DESCRIPTION
## Summary

Adds [SandBase CLI](https://github.com/sandbaseai/cli) to **Tools & Utilities → Server Managers**.

The CLI is distinct from the SandBase Harness submission in #411: it connects and manages SandBase MCP access across 17+ supported AI clients rather than providing a code-execution server. Its documented management features include:

- OAuth Device Flow with PKCE
- ownership-aware configuration updates
- exact rollback and safe unregister behavior
- client diagnostics and zero-change JSON catalog preview
- stdio MCP bridge and native Agent Skill setup

The project is Apache-2.0 licensed, published as `@sandbaseai/cli`, documents eight languages, and its current CI passes 150 tests plus npm package auditing.

## Validation

- verified the entry uses the existing Server Managers format
- `git diff --check`

## Disclosure

Submitted from the official `sandbaseai` organization fork.