### PR TITLE
Add open-mcp-apps to Note Taking category

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
-- open-mcp-apps — https://github.com/2nd1st/open-mcp-apps (MCP Apps engine: the AI writes a single-file HTML app — todo board, habit tracker, dashboard, reading list — saves it to a registry, and reopens it by name in any later chat. Data lives in SQLite-backed collections with an append-only change ledger, so it outlives the conversation. 33 tools, stdio, Node 22+. Ships a 22-app App Store. AGPL-3.0 engine, MIT apps.)
+- open-mcp-apps — https://github.com/2nd1st/open-mcp-apps (MCP Apps engine: the AI writes a single-file HTML app — todo board, habit tracker, dashboard, reading list — saves it to a registry, and reopens it by name in any later chat. Data lives in SQLite-backed collections with an append-only change ledger, so it outlives the conversation. 33 tools, stdio, Node 22+. Ships a 22-app App Store. MIT licensed. Install: `npx -y @2nd1st/open-mcp-apps`.)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Personal knowledge and notes integrations.
 - Todoist — https://github.com/abhiz123/todoist-mcp-server
 - Google Keep — https://github.com/feuerdev/keep-mcp
 - OMEGA — https://github.com/omega-memory/core (Persistent memory for AI coding agents. #1 on LongMemEval benchmark (95.4%). 12 MCP tools with semantic search, auto-capture, and intelligent forgetting. Local-first, zero cloud dependency.)
+- open-mcp-apps — https://github.com/2nd1st/open-mcp-apps (MCP Apps engine: the AI writes a single-file HTML app — todo board, habit tracker, dashboard, reading list — saves it to a registry, and reopens it by name in any later chat. Data lives in SQLite-backed collections with an append-only change ledger, so it outlives the conversation. 33 tools, stdio, Node 22+. Ships a 22-app App Store. AGPL-3.0 engine, MIT apps.)
 
 ---
 


### PR DESCRIPTION
Adds one line to **Category: Note Taking (📝)**, matching the existing `Name — URL (description)` format.

**What it is:** an MCP Apps engine. The AI writes a single-file HTML app — todo board, habit tracker, dashboard, reading list — saves it to a registry, and reopens it by name in any later chat. Data lives in SQLite-backed collections with an append-only change ledger, so it outlives the conversation and the AI and the human edit the same store. Ships a 22-app App Store. 33 tools, stdio, Node 22+. AGPL-3.0 engine, MIT apps.

**On the category:** there is no general productivity category, and Note Taking ("personal knowledge and notes integrations") already holds Todoist, which is the closest neighbour to what people actually build with this. Glad to move it if you would prefer another one.

Touches `README.md` only, in line with previously merged entry PRs. Not previously listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)