### PR TITLE
Add Palisade DMARC Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Security-focused servers and scanning tools.
 - Vulert — https://vulert.com
 - Thales / CDSP servers — various MCP integrations for secrets & keys
 - Agent OS — https://github.com/imran-siddique/agent-os — Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+- Palisade DMARC Agent — https://github.com/palisadeemail/palisade-mcp — Official MCP server for AI-powered management of DMARC, SPF, DKIM, BIMI, MTA-STS, DNS records, domain verification, and remediation tasks.
 
 ---
 


### PR DESCRIPTION
Adds the official Palisade MCP server to the Security category. It enables AI-agent management of DMARC, SPF, DKIM, BIMI, MTA-STS, DNS records, domain verification, and remediation tasks. Validation: public source and official registry entry verified; git diff --check passed.