### PR TITLE
Add Live Tennis API MCP server (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- Live Tennis API (real-time tennis scores, fixtures, H2H, rankings and model win probability — event data for agents pricing tennis markets) — https://github.com/livetennisapi/livetennisapi-mcp
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -403,6 +403,7 @@ Shell、操作系统与任务自动化相关。
 - PayPal（⭐） — https://github.com/paypal/agent-toolkit
 - Stripe（⭐） — https://github.com/stripe/agent-toolkit
 - LongPort OpenAPI（⭐） — https://github.com/longportapp/openapi/tree/main/mcp
+- Live Tennis API（实时网球比分、赛程、H2H、排名与模型胜率 — 供智能体为网球预测市场定价的赛事数据） — https://github.com/livetennisapi/livetennisapi-mcp
 
 ---
 


### PR DESCRIPTION
Adds livetennisapi-mcp (190★, MIT) under Finance — market-data side: 24 tools for real-time tennis scores, fixtures, players, H2H, rankings and model win probability, framed for agents pricing tennis event markets. Free tier; hosted remote endpoint + npm package. Applied to every README translation carrying the Finance section. Disclosure: I run this API.