### PR TITLE
Add Wondel.ai Skills MCP to Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- Wondel.ai Skills MCP — https://github.com/mjaskolski/wondel-skills-mcp
 
 ---
 


### PR DESCRIPTION
Read-only remote MCP server (Streamable HTTP, no auth) over 50 book-based agent skills and 12 guided journeys. Endpoint: https://skills.wondel.ai/mcp — published in the official MCP registry as io.github.mjaskolski/wondel-skills-mcp.