### PR TITLE
Add AI Developer Toolkit MCP to Search & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Web fetching, scraping, and search.
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
+- AI Developer Toolkit MCP — https://github.com/mjaskolski/developer-toolkit-mcp
 
 ---
 


### PR DESCRIPTION
Read-only remote MCP endpoint (Streamable HTTP, no auth, no API key) over 950+ AI-development guides (Cursor, Claude Code, Codex) in EN+PL: search + fetch tools. Endpoint: https://developertoolkit.ai/mcp — published in the official MCP registry as io.github.mjaskolski/developer-toolkit-mcp.