### PR TITLE
Add Pocket Drives MCP to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Mapping and geolocation.
 - Google Maps — https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps
 - IPLocate — https://github.com/iplocate/mcp-server-iplocate
 - IP2Location.io — https://github.com/ip2location/mcp-ip2location-io
+- Pocket Drives — https://github.com/RevList/pocket-drives-mcp — Public remote MCP for a P2P luxury/exotic/EV rental marketplace. Search, quote, and browse independent hosts. Streamable HTTP at https://pocketdrives.ai/mcp, no auth. Booking finishes in the iOS app.
 - QGIS — https://github.com/jjsantos01/qgis_mcp
 
 ---


### PR DESCRIPTION
Adds Pocket Drives to Location Services, after IP2Location.io / before QGIS.

- Listing repo: https://github.com/RevList/pocket-drives-mcp
- Remote Streamable HTTP (no auth): https://pocketdrives.ai/mcp
- Official registry: `ai.pocketdrives/pocket-drives`
- Glama: https://glama.ai/mcp/connectors/ai.pocketdrives/pocket-drives

Pocket Drives is a P2P luxury/exotic/EV rental marketplace. Independent hosts; PocketList Inc builds the platform. This server searches, quotes, and browses. Booking finishes in the iOS app.

Single new bullet only.