### PR TITLE
Add Magic Hour to AI Services category

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- Magic Hour (⭐) — https://magichour.ai/mcp (hosted MCP server for AI video/image/audio generation — Sora 2, Veo 3.1, Kling, Flux, face swap, lip sync; endpoint https://mcp.magichour.ai/)
 
 ---
 


### PR DESCRIPTION
Adds Magic Hour, the official hosted MCP server for AI video, image, and audio generation (Sora 2, Veo 3.1, Kling, Flux, face swap, lip sync, etc.) via one API key.

- Docs: https://magichour.ai/mcp — endpoint: https://mcp.magichour.ai/ (Streamable HTTP, OAuth or bearer API key)
- API docs: https://docs.magichour.ai — legacy self-hosted server: https://github.com/magichourhq/magic-hour-mcp
- Free tier: 400 credits on signup plus 100/day, no card required.