### PR TITLE
Add Coldrig to Communication category

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Integration with chat and messaging platforms.
 - Atlassian — https://github.com/sooperset/mcp-atlassian
 - Carbon Voice (⭐) — https://github.com/PhononX/cv-mcp-server
 - ntfy — https://github.com/gitmotion/ntfy-me-mcp
+- Coldrig (⭐) — https://github.com/YS-projectcalc/agent-cold-email
 
 ---
 


### PR DESCRIPTION
Adds Coldrig (`YS-projectcalc/agent-cold-email`), agent-operated cold-email infrastructure over an official MCP server, HTTP API, and npm CLI. It exposes 28 high-level intents spanning domain/mailbox provisioning, warmup state, campaign execution, reply handling, and health guardrails, and ships a free no-send sandbox (`npx agent-cold-email demo`). MIT-licensed, hosted MCP endpoint at https://api.coldrig.dev/mcp. Placed in Communication alongside the list's other messaging/email-infrastructure entries.