### PR TITLE
Add Cohesivity to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Cloud vendors and orchestration.
 - Tinybird (⭐) — https://github.com/tinybirdco/mcp-tinybird
 - Google Cloud Run — https://github.com/GoogleCloudPlatform/cloud-run-mcp
 - Render — https://render.com/docs/mcp-server
+- Cohesivity (⭐) — https://github.com/cohesivity-org/cohesivity-plugin — cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.
 
 ---
 


### PR DESCRIPTION
Adds Cohesivity to Category: Cloud Platforms.

cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.

The official repository bundles the hosted OAuth MCP, no-signup local bootstrap MCP, skill, and plugin. This repository catalogs MCP servers, so the change adds one MCP entry linking that complete bundle.

Links:
- Repository: https://github.com/cohesivity-org/cohesivity-plugin
- Hosted MCP: https://cohesivity.ai/mcp/manage
- Authentication documentation: https://cohesivity.ai/auth.md
- Glama listing: https://glama.ai/mcp/servers/cohesivity-org/cohesivity-plugin

Disclosure: This is an official Cohesivity submission.
