### PR TITLE
Add BuyWhere MCP server to E-Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Books, libraries, and creative tools.
 
 Commerce and marketplace integrations.
 
+- BuyWhere — https://github.com/BuyWhere/buywhere-mcp — Cross-border product catalog (370M+ products, SG/MY/VN/TH/PH/US/JP) with `deliver_to` shipping signals. Hosted at `https://mcp.buywhere.ai/mcp`. OAuth 2.1 bearer auth. Official MCP Registry `io.github.BuyWhere/buywhere-mcp@1.1.0`. Install via `npx -y @buywhere/buywhere`.
 - Mercado Libre — https://mcp.mercadolibre.com/
 - Gunsnation — https://github.com/DynamicDeals/mcp-server-gunsnation
 - ShopSavvy (⭐) — https://github.com/shopsavvy/shopsavvy-mcp-server


### PR DESCRIPTION
## What
Adds [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) to the E-Commerce category, as a new line at the top of the existing list (alphabetically before Mercado Libre).

## Server
- v1.1.0 (2026-08-22) — 370M+ live products across SG, MY, VN, TH, PH, US, JP with `deliver_to` shipping signals
- 13 tools: search_products, find_best_price, get_deals, get_product, etc.
- OAuth 2.1 bearer auth (no email/signup)
- Hosted at https://mcp.buywhere.ai/mcp
- Official MCP Registry: io.github.BuyWhere/buywhere-mcp@1.1.0 (isLatest: true)
- MIT license
- Install: npx -y @buywhere/buywhere