### PR TITLE
Add Concord MCP to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ AI model & ML service integrations.
 
 Developer-focused MCP servers and tools.
 
+- Concord MCP — https://github.com/Get-Concord-AI/concord-mcp — Cross-harness communication and shared work-state for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build. Install with `npx -y @concord-ai/concord-mcp`.
 - CentralMind/Gateway — https://github.com/centralmind/gateway
 - Currents (⭐) — https://github.com/currents-dev/currents-mcp
 - Octocode — https://github.com/bgauryy/octocode-mcp


### PR DESCRIPTION
## Summary

Adds Concord MCP to the Development Tools category. Concord gives Claude Code, Codex, Cursor, Gemini CLI, and Grok Build shared task state and direct cross-harness messaging through MCP.

The entry includes the public repository and npm install command. The link resolves and `git diff --check` passes.

Disclosure: I maintain Concord MCP.