### PR TITLE
Add Lumi App Finder to Search & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Web fetching, scraping, and search.
 - Apify Actors & RAG Web Browser — https://github.com/apify/actors-mcp-server and https://github.com/apify/mcp-server-rag-web-browser
 - Coupang MCP — https://github.com/uju777/coupang-mcp - Korean e-commerce search with Rocket Delivery filtering
 - Naver Search MCP — https://github.com/uju777/mcp-server-naver-search - Naver Shopping, Cafe, News search for Korean users
+- Lumi App Finder — https://github.com/alice51849/lumi-mcp - Offline first-party iOS app finder: matches a task or buyer need to live App Store apps in 50 Apple locales and returns storefront links
 - Scrapeless and many web-scraping-focused MCP servers are listed in Community Servers.
 
 ---


### PR DESCRIPTION
Adds one line to **Category: Search & Web**.

**Lumi App Finder** — https://github.com/alice51849/lumi-mcp (MIT)

A stdio MCP server with a single read-only tool, `find_ios_apps`, that matches a task, app name, or buyer need to live iOS apps and returns editorially localized context, the purchase model, a guide link, and a direct App Store link for the matching storefront. Node.js, zero runtime dependencies; the catalog snapshot is bundled, so the server makes no network request and query text never leaves the local process. No account or API key.

Published in the official MCP Registry as `io.github.alice51849/lumi-app-finder`.

**Disclosure:** this is a first-party publisher catalog — Lumi Studio develops every listed app. Results are publisher-authored text relevance matches, not an independent ranking, review, or measured search volume.
