### PR TITLE
Add Rankrat to Marketing MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- Rankrat — https://github.com/psyb0t/rankrat
 
 ---
 


### PR DESCRIPTION
Adds my self-hosted MCP server [Rankrat](https://github.com/psyb0t/rankrat) to Marketing. It connects agents to Search Console, GA4, Bing Webmaster, PageSpeed, CrUX, Cloudflare, Clarity, and Google Tag Manager.