### PR TITLE
Add ParlayAPI to Finance category

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- ParlayAPI (sports betting odds, player props, and prediction-market data from 45+ sportsbooks and sources across 90+ sports, with verdict, parlay grading, arbitrage, +EV, consensus, and middles tools) - https://github.com/JacobiusMakes/parlay-api-mcp
 
 ---
 


### PR DESCRIPTION
Adds ParlayAPI to the Finance category (closest fit: betting-market and prediction-market data; there is no Sports category).

Disclosure: I am the founder of ParlayAPI, submitting our own MCP server.

- Repo: https://github.com/JacobiusMakes/parlay-api-mcp (public, MIT)
- Package: `parlayapi-mcp` on PyPI, latest 0.3.4: https://pypi.org/project/parlayapi-mcp/
- Official MCP Registry id: `io.github.JacobiusMakes/parlayapi` (active, 0.3.4)
- Install: `uvx parlayapi-mcp` (stdio, Python 3.10+); 22 tools, 9 of them keyless including a free-tier signup tool
- Coverage (45+ sportsbooks and sources, 90+ sports) is self-verifiable via https://parlay-api.com/v1/sports
- Docs: https://parlay-api.com/docs

One entry, one line, matching the existing list format.
