### PR TITLE
Add OmniSim MCP to Robotics & Physical AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ Orchestration and data pipeline platforms.
 Robotics and device control.
 
 - Bagel — https://github.com/Extelligence-ai/bagel
+- OmniSim MCP — https://github.com/omnilink-tech/omnisim/tree/main/packages/omnisim-mcp — First-party local stdio adapter for OmniSim's robotics World Harness. Agents can load or hot-sync worlds, inspect scene and robot state, aim cameras, capture screenshots, step/reset simulation, and read contacts and controller events. Zero Python runtime dependencies; requires a local OmniSim harness and is currently source-install only, not published on PyPI.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds OmniSim MCP to the existing Robotics & Physical AI section.

OmniSim MCP is OmniLink's first-party local stdio adapter for the OmniSim World Harness. It exposes robotics world loading and hot-sync, scene and robot inspection, camera framing and screenshots, simulation stepping/reset, contacts, diagnostics, and controller events to MCP clients.

- Source: https://github.com/omnilink-tech/omnisim/tree/main/packages/omnisim-mcp
- Install: `pip install -e packages/omnisim-mcp`
- Transport: stdio
- License: Apache-2.0
- Requires: local OmniSim World Harness
- Distribution: source-only; not yet published on PyPI

Self-submission from the OmniLink maintainers.