### PR TITLE
Add BestPrice Shopping to E-Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ Commerce and marketplace integrations.
 - Mercado Libre — https://mcp.mercadolibre.com/
 - Gunsnation — https://github.com/DynamicDeals/mcp-server-gunsnation
 - ShopSavvy (⭐) — https://github.com/shopsavvy/shopsavvy-mcp-server
+- BestPrice Shopping (⭐) — https://github.com/TheBestCo/bestprice-mcp (remote: https://mcp.bestprice.gr/mcp)
 
 ---
 


### PR DESCRIPTION
Adds the official BestPrice.gr shopping MCP server to the E-Commerce category.

The public Streamable HTTP endpoint is `https://mcp.bestprice.gr/mcp`; it is read-only, requires no authentication, and exposes product search, current offer comparison, and price history for the Greek market. It is also published as `gr.bestprice/mcp@1.5.0` in the official MCP Registry.

Source and connection examples: https://github.com/TheBestCo/bestprice-mcp
Public documentation: https://www.bestprice.gr/mcp