### PR TITLE
Add SandBase CLI to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Identity and access management.
 
 Single MCP endpoints that expose many integrations.
 
+- SandBase CLI — https://github.com/sandbaseai/cli — Local MCP bridge connecting 25 AI client targets to 2,000+ AI models and APIs through six discovery, inspection, execution, run-tracking, and account tools.
 - SkillBoss — https://github.com/heeyo-life/skillboss-mcp — One API key for 100+ AI services (Claude, GPT, Gemini, DeepSeek, images, video, data scraping, payments, email, and more). OpenAI-compatible. Works in Claude Code, Cursor, Windsurf.
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -481,6 +481,7 @@ Shell、操作系统与任务自动化相关。
 
 通过单一 MCP 端点访问多个应用和工具。
 
+- SandBase CLI — https://github.com/sandbaseai/cli — 本地 MCP 桥接器，通过六个发现、检查、执行、运行追踪和账户工具，将 25 个 AI 客户端目标连接至 2,000+ 个 AI 模型与 API。
 - MCPJungle — https://github.com/mcpjungle/MCPJungle
 - Rube — https://rube.composio.dev
 - Pipedream — https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol
@@ -646,4 +647,3 @@ Shell、操作系统与任务自动化相关。
 - 在生产环境中优先使用官方厂商维护的服务器（标注为 ⭐）。
 - 查阅每个服务器仓库，了解其支持的传输方式（stdio、SSE、HTTP）、鉴权方式与示例客户端。
 - 该生态系统发展迅速，新的服务器、客户端和框架不断加入。维护者请确保仓库包含清晰的安装与安全说明。
-


### PR DESCRIPTION
## Summary

Adds SandBase CLI to the Aggregators category in the English and Chinese lists.

SandBase CLI is an Apache-2.0 local MCP bridge that connects 25 AI client targets to 2,000+ AI models and APIs through six tools for discovery, schema/pricing inspection, execution, asynchronous result retrieval, run history, and account balance.

## Verification

- Source: https://github.com/sandbaseai/cli
- Official MCP Registry: `io.github.sandbaseai/cli@0.1.17`
- Pinned release: https://github.com/sandbaseai/cli/releases/tag/v0.1.17
- Related listing request: closes #423
- `git diff --check` passes

The change is limited to one concise entry in each localized README.