### PR TITLE
Add SandBase CLI MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Single MCP endpoints that expose many integrations.
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy
 - MCP Aggregator / Combine — https://github.com/nazar256/combine-mcp
 - Magg — https://github.com/sitbon/magg
-- SandBase CLI — https://github.com/sandbaseai/cli — Local MCP bridge for discovering and running 2,000+ AI models and APIs from supported AI clients.
+- SandBase CLI — https://github.com/sandbaseai/cli — Local MCP bridge for discovering and running 2,000+ AI models and APIs from supported AI clients. Install with `npx -y @sandbaseai/cli@0.1.14 connect --client claude-desktop`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ Single MCP endpoints that expose many integrations.
 - Plugged.in — https://github.com/VeriTeknik/pluggedin-mcp-proxy
 - MCP Aggregator / Combine — https://github.com/nazar256/combine-mcp
 - Magg — https://github.com/sitbon/magg
+- SandBase CLI — https://github.com/sandbaseai/cli — Local MCP bridge for discovering and running 2,000+ AI models and APIs from supported AI clients.
 
 ---
 


### PR DESCRIPTION
Adds SandBase CLI to the Aggregators category.

- Project: https://github.com/sandbaseai/cli
- The README describes its local MCP bridge and 2,000+ AI model/API catalog.
- This is a hosted-service listing, not a claim that every model is bundled locally.