### PR TITLE
Add BulkTranscripts YouTube MCP server (Social Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Social platforms integration.
 
 - BlueSky — https://github.com/keturiosakys/bluesky-context-server
 - YouTube — https://github.com/anaisbetts/mcp-youtube and https://github.com/kimtaeyoon83/mcp-server-youtube-transcript
+- BulkTranscripts (hosted remote MCP: bulk YouTube transcripts, video/channel/playlist search, search inside a channel, and free new-upload tracking; no signup, free tier) — https://github.com/pratie/bulktranscripts-mcp
 - Spotify — https://github.com/varunneal/spotify-mcp
 - TikTok — https://github.com/Seym0n/tiktok-mcp
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp


### PR DESCRIPTION
Adds BulkTranscripts to the Social Media category.

- **Repo:** https://github.com/pratie/bulktranscripts-mcp (MIT)
- **Endpoint:** `https://bulktranscripts.co/mcp` (Streamable HTTP)
- **Auth:** none required — keyless free tier (30 transcripts per IP); optional `Authorization: Bearer <license key>`
- **7 tools:** `get_transcript`, `get_transcripts` (batch up to 20), `search_youtube`, `search_channel`, `get_channel_videos`, `get_playlist_videos`, `get_latest_videos` (always free)
- **Docs:** https://bulktranscripts.co/youtube-mcp-server
- Published to the official MCP Registry as `co.bulktranscripts/youtube`

Placed next to the existing YouTube entry. No duplicate for this URL or project name.