### PR TITLE
Add DDMarketer to Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- DDMarketer (validated SaaS opportunities from real user complaints) — https://github.com/CodePhantom-1/ddmarketer-mcp
 
 ---
 


### PR DESCRIPTION
Adds DDMarketer — a remote (streamable HTTP) MCP server for validated SaaS opportunities mined from real user complaints across 8 public sources, scored 0-100 for commercial intent.

Endpoint: `https://www.ddmarketer.com/api/mcp` — hosted, no install, no API key for the free tier.
Official MCP Registry: `io.github.CodePhantom-1/ddmarketer-mcp` (active).