### PR TITLE
docs: add SandBase CLI MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ AI model & ML service integrations.
 - OpenAI — https://github.com/pierrebrunelle/mcp-server-openai
 - OpenAI Compatible Chat — https://github.com/pyroprompts/any-chat-completions-mcp
 - Perplexity — https://github.com/tanigami/mcp-server-perplexity
+- SandBase CLI — https://github.com/sandbaseai/cli — Open-source command-line MCP bridge for accessing 2,000+ AI models through one interface.
 - LlamaCloud — https://github.com/run-llama/mcp-server-llamacloud
 - HuggingFace Spaces — https://github.com/evalstate/mcp-hfspace
 - PiAPI — https://github.com/apinetwork/piapi-mcp-server


### PR DESCRIPTION
## Summary
- add SandBase CLI to the Clients section
- link the canonical repository and note its local bridge for discovering and running 2,000+ AI models

Disclosure: I contribute to SandBase CLI. This is a factual self-submitted entry and follows the existing list format.