### PR TITLE
Add NoClick to Workflow Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Automation platforms and workflow tools.
 
 - Make (⭐) — https://github.com/integromat/make-mcp-server
 - Make (2) — https://github.com/danishashko/make-mcp — Unofficial community fork with 200+ modules, auto-healing, and router support
+- NoClick (⭐) — https://github.com/noclickapp/noclick — Build agents to automate any background task. Works with your ChatGPT/Claude subscription. Remote MCP: https://api.noclick.io/mcp
 - Taskade (⭐) — https://github.com/taskade/mcp
 - Zapier — https://zapier.com/mcp
 - Pipedream — https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol


### PR DESCRIPTION
Adds NoClick's hosted OAuth MCP server to the Workflow Automation category.\n\nNoClick lets users build agents that automate background tasks and workflows using their existing ChatGPT or Claude subscription.\n\n- MCP endpoint: https://api.noclick.io/mcp\n- Product: https://www.noclick.com/mcp\n- Setup docs: https://docs.noclick.com/mcp/setup