### PR TITLE
Add Wine Labs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
-- Wine Labs (fine-wine identity matching, pricing, auctions, exchange data, merchant comparisons, portfolios, and cellar workflows; hosted Streamable HTTP with browser OAuth) — https://github.com/imiraoui/winelabs-mcp
+- Wine Labs (fine-wine identity matching, pricing, auctions, exchange data, merchant comparisons, portfolios, and cellar workflows; hosted Streamable HTTP with browser OAuth) — https://winelabs.ai/agents ([public metadata](https://github.com/imiraoui/winelabs-mcp))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Payments, market data, and finance tools.
 - LongPort OpenAPI (⭐) — https://github.com/longportapp/openapi/tree/main/mcp
 - x402engine-mcp (50+ pay-per-call APIs for AI agents via HTTP 402 micropayments) — https://github.com/agentc22/x402engine-mcp
 - awesome-x402 (curated directory of x402 payment protocol MCP servers and tools) — https://github.com/xpaysh/awesome-x402
+- Wine Labs (fine-wine identity matching, pricing, auctions, exchange data, merchant comparisons, portfolios, and cellar workflows; hosted Streamable HTTP with browser OAuth) — https://github.com/imiraoui/winelabs-mcp
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the official Wine Labs hosted MCP server to Financial Services.
- Documents the Streamable HTTP endpoint and browser OAuth accurately.
- Links the canonical [Wine Labs MCP product page](https://winelabs.ai/agents) while retaining public connection metadata and installation documentation.

## Verification

- Public MCP endpoint returns the expected OAuth challenge.
- OAuth protected-resource discovery, product, install, privacy, and terms URLs return HTTP 200.

This is a maintainer self-submission prepared with an automated coding agent.