### PR TITLE
Add DC Hub to Research & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Papers, datasets, and domain data.
 - Probe.dev — https://mcp.probe.dev
 - OpenNutrition — https://github.com/deadletterq/mcp-opennutrition
 - Congress (legislative data) — https://github.com/amurshak/congressMCP
+- DC Hub (data-center, power-grid & energy infrastructure) — https://github.com/azmartone67/dchub-mcp-server
 
 ---
 


### PR DESCRIPTION
Adds DC Hub — a remote MCP server for data-center, power-grid, fiber and natural-gas infrastructure intelligence (site selection, grid capacity, interconnection queues, energy prices).

Endpoint: https://dchub.cloud/mcp (remote, no install; free tier needs no key)
Repo: https://github.com/azmartone67/dchub-mcp-server

One-line addition at the bottom of the Research & Data category, matching the existing `- Name — url` format.