### PR TITLE
docs: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ AI model & ML service integrations.
 Developer-focused MCP servers and tools.
 
 - CentralMind/Gateway — https://github.com/centralmind/gateway
+- SandBase Harness — https://github.com/sandbaseai/sandbase-harness — 本地优先的 AI Agent 运行时，通过 stdio MCP Bridge 提供持久化会话、沙箱工具、记忆、凭据、审计与回放；支持 Local、Docker、Kubernetes 和自托管部署。
 - Currents (⭐) — https://github.com/currents-dev/currents-mcp
 - Octocode — https://github.com/bgauryy/octocode-mcp
 - OpenAPI Schema Explorer — https://github.com/kadykov/mcp-openapi-schema-explorer


### PR DESCRIPTION
## Summary

Add SandBase Harness to the Development Tools category.

SandBase Harness is a local-first AI agent runtime with a stdio MCP bridge for persistent sessions, sandboxed tools, memory, credentials, audit, and replay. It supports Local, Docker, Kubernetes, and self-hosted deployment.

- Project: https://github.com/sandbaseai/sandbase-harness
- MCP Registry: https://registry.modelcontextprotocol.io/?q=io.github.sandbaseai%2Fsandbase-harness
- Current release: v0.3.8
