### PR TITLE
Add VASTlint to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Marketing and analytics tools.
 - Fathom Analytics — https://github.com/mackenly/mcp-fathom-analytics
 - Facebook Ads — https://github.com/gomarble-ai/facebook-ads-mcp-server
 - Google Ads — https://github.com/gomarble-ai/google-ads-mcp-server
+- VASTlint — https://github.com/aleksUIX/vastlint (hosted MCP https://vastlint.org/mcp, auth none)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add [aleksUIX/vastlint](https://github.com/aleksUIX/vastlint) under Marketing.
- Hosted MCP: `https://vastlint.org/mcp` (auth none). Registry id `io.github.aleksUIX/vastlint`.

## Test plan
- [ ] Link opens the public repo
- [ ] Hosted URL responds (Streamable HTTP / SSE)