### PR TITLE
Add SandBase Harness to sandbox servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Provides access to local or remote file systems with configurable permissions.
 Secure sandbox environments for code execution.
 
 - Microsandbox (⭐) — https://github.com/microsandbox/microsandbox
+- SandBase Harness — https://github.com/sandbaseai/sandbase-harness
 - E2B (⭐) — https://github.com/e2b-dev/mcp-server
 - Docker (QuantGeekDev) — https://github.com/QuantGeekDev/docker-mcp
 


### PR DESCRIPTION
## Add SandBase Harness

Add SandBase Harness to the Sandbox & Virtualization category. It is a self-hosted MCP runtime with local, Docker, Kubernetes, and worker sandbox providers, plus tool permissions, approvals, credentials, and audit/replay.

Project: https://github.com/sandbaseai/sandbase-harness
Current release: v0.3.8

Disclosure: I maintain/contribute to SandBase Harness.