### PR TITLE
Add Magic Hour MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ MCP servers for device and IoT integration.
 Books, libraries, and creative tools.
 
 - MCP Open Library — https://github.com/8enSmith/mcp-open-library
+- Magic Hour — https://github.com/magichourhq/magic-hour-mcp — Official hosted MCP server for generating and editing images, videos, and audio through Streamable HTTP.
 - Pollinations — https://github.com/pollinations/model-context-protocol
 
 ---


### PR DESCRIPTION
## Summary

Adds Magic Hour's official hosted MCP server to the Art & Culture category, linking the first-party repository and describing its image, video, and audio generation/editing capabilities.

Official Registry: `io.github.magichourhq/magic-hour`
