### PR TITLE
Add local-gpu-imagegen to AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ AI model & ML service integrations.
 - Chronulus AI — https://github.com/ChronulusAI/chronulus-mcp
 - Creatify — https://github.com/TSavo/creatify-mcp
 - ZenML (⭐) — https://github.com/zenml-io/mcp-zenml
+- Local GPU Imagegen — https://github.com/ChevalGrand520/local-gpu-imagegen
 
 ---
 


### PR DESCRIPTION
Adds Local GPU Imagegen to the AI Services category.

Local GPU Imagegen is an MCP server giving AI agents confirmation-gated access to local NVIDIA GPU image generation through existing ComfyUI workflows, with SHA-256 model identity, explicit license approval, and no silent model downloads. Windows 10/11 x64 NVIDIA, 17 tools over stdio, MIT licensed. Published on PyPI (local-gpu-imagegen 0.9.1) and the official MCP Registry (io.github.ChevalGrand520/local-gpu-imagegen).