### PR TITLE
Add Melaya (Android phone + browser control) under System Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Shell, OS, and task automation.
 - Windows Control — https://github.com/Cheffromspace/nutjs-windows-control
 - Command Line — https://github.com/phialsbasement/cmd-mcp-server
 - Apple Shortcuts — https://github.com/recursechat/mcp-server-apple-shortcuts
+- Melaya (Android phone + browser) — https://melaya.org/en/product/mcp — Remote OAuth 2.1 server that drives a paired Android phone by reading its accessibility tree and tapping, typing and swiping, so it works in any app with no per-app integration. Also drives a paired browser and runs agent pipelines. Scoped to apps the user allow-lists; publishing under their identity needs on-device approval. Endpoint: https://api.melaya.org/mcp
 
 ---
 


### PR DESCRIPTION
Adds Melaya under **Category: System Automation**, next to Apple Shortcuts and Windows Control, since those are its closest neighbours on this list.

### What it is

A remote MCP server that drives a paired Android phone. It reads the screen through Android's accessibility tree and then taps, types and swipes, which means it works inside any app without a per-app integration or a vendor API. It also drives a paired browser and runs agent pipelines.

Remote only, so there is nothing to install:

    https://api.melaya.org/mcp

Auth is OAuth 2.1 with PKCE and dynamic client registration (RFC 7591), so users paste no API key and set no config values.

### On safety, since this one touches a physical device

- The agent can only operate apps the user has explicitly allow-listed, and that list can only be narrowed from the agent side, never widened.
- Anything that posts under the user's own identity stages an approval card on the phone and does not send until they approve it.
- Browser access is limited to origins the user grants on their own settings page.

### Category note

Happy to move it. System Automation felt right because Apple Shortcuts and Windows Control are already there, but Aggregators would also make sense given the pipelines reach 6k+ tools through connectors. Your call.

### On the call for translators

I saw the note in the README. Melaya ships a French locale already, so if a French README would be genuinely useful to you rather than a maintenance burden, I am happy to open a separate PR for it. Say the word and I will do it properly rather than machine translating it.

Repo: https://github.com/melaya-labs/melaya-mcp (Apache-2.0)
Docs: https://github.com/melaya-labs/melaya/blob/main/docs/mcp.md
