### PR TITLE
Add BulkPublish to Social Media MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Social platforms integration.
 - Instagram DMs — https://github.com/trypeggy/instagram_dm_mcp
 - X/Twitter — https://github.com/mbelinky/x-mcp-server
 - Social Neuron (52 MCP tools for AI-powered social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning) — https://github.com/socialneuron/mcp-server [npm: @socialneuron/mcp-server]
+- BulkPublish — REST API and MCP server for AI agents to adapt, schedule, publish, and analyze social media content across platforms — https://github.com/azeemkafridi/bulkpublish-api [npm: @bulkpublish/mcp-server]
 
 ---
 


### PR DESCRIPTION
## Summary

- Add BulkPublish to the Social Media category.
- Link the source repository and published npm MCP package.
- Describe AI-agent social adaptation, scheduling, publishing, and analytics capabilities.

This is a self-submission; I am affiliated with BulkPublish. Canonical references:
- Skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
- API/MCP docs: https://app.bulkpublish.com/docs

The MCP server is write-capable and requires an API key; users should review and approve external publishing actions.

## Checks

- git diff --check
- Direct HTTP check of the official website passed.