### PR TITLE
Add Process Street MCP Server to Workflow Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Cloud vendors and orchestration.
 
 Automation platforms and workflow tools.
 
+- Process Street (⭐) - https://github.com/process-street/process-street-mcp - Connects AI agents to Process Street workflows, tasks, runs, data sets, and operational records through Streamable HTTP.
 - Make (⭐) — https://github.com/integromat/make-mcp-server
 - Make (2) — https://github.com/danishashko/make-mcp — Unofficial community fork with 200+ modules, auto-healing, and router support
 - Taskade (⭐) — https://github.com/taskade/mcp


### PR DESCRIPTION
Adds Process Street's official hosted MCP server to Workflow Automation.

It connects AI agents to Process Street workflows, tasks, runs, data sets, and operational records through Streamable HTTP.