### PR TITLE
Add speakai/speakai-mcp (Official Servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Official integrations are maintained by companies building production-ready MCP 
 - Cloudflare — https://github.com/cloudflare/mcp-server-cloudflare (⭐)
 - GitHub — https://github.com/github/github-mcp-server (official)
 - Notion — https://github.com/makenotion/notion-mcp (official)
+- Speak AI — https://github.com/speakai/speakai-mcp (official)
 - Stripe — https://github.com/stripe/agent-toolkit/tree/main (⭐)
 - PayPal — https://github.com/paypal/agent-toolkit/tree/main (⭐)
 - Tinybird — https://github.com/tinybirdco/mcp-tinybird (⭐)


### PR DESCRIPTION
- Official MCP server implementation built and maintained by the Speak AI team.
- Repo: https://github.com/speakai/speakai-mcp · npm: https://www.npmjs.com/package/@speakai/mcp-server
- Lets an AI assistant transcribe, search, and analyze audio/video recordings in a Speak AI workspace: speech-to-text in 100+ languages with speaker labels, AI summaries and sentiment, call scoring on custom rubrics, clip creation, and captions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECfv85U3ZpQrHapVskBN8z