### PR TITLE
Add Lizard to Cloud Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Cloud vendors and orchestration.
 - Tinybird (⭐) — https://github.com/tinybirdco/mcp-tinybird
 - Google Cloud Run — https://github.com/GoogleCloudPlatform/cloud-run-mcp
 - Render — https://render.com/docs/mcp-server
+- Lizard — https://github.com/lizard-build/lizard-mcp
 
 ---
 


### PR DESCRIPTION
Adds the official MCP server for Lizard (https://lizard.build), an AI-native deployment platform for coding agents.

Disclosure: I maintain this server.

Repo: https://github.com/lizard-build/lizard-mcp (MIT). 33 tools over Streamable HTTP — services, managed Postgres/Redis/S3, logs and metrics, secrets, domains. OAuth 2.1 as an MCP protected resource. Quality grade A on Glama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)